### PR TITLE
fix(for_each): coerce stringified bools from Jinja-rendered templates

### DIFF
--- a/snowcap/resources/resource.py
+++ b/snowcap/resources/resource.py
@@ -183,6 +183,22 @@ def _coerce_resource_field(field_value, field_type):
             return float(field_value)
         else:
             raise TypeError
+    elif field_type is bool:
+        if isinstance(field_value, bool):
+            return field_value
+        elif isinstance(field_value, str):
+            # Accept both YAML-style ("true"/"false") and Jinja-rendered ("True"/"False")
+            # — Jinja stringifies Python bools as "True"/"False" when a template like
+            # "{{ each.value.auto_resume }}" expands inside a for_each.
+            field_value_lower = field_value.lower()
+            if field_value_lower == "true":
+                return True
+            elif field_value_lower == "false":
+                return False
+            else:
+                raise TypeError
+        else:
+            raise TypeError
     else:
         # Typecheck all other field types (str, int, etc.)
         if not isinstance(field_value, field_type):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -643,10 +643,32 @@ class TestTypeCoercionEdgeCases:
         except TypeError:
             pass  # Strict typing rejects float for int field
 
-    def test_bool_string_not_coerced(self):
-        """Boolean string not auto-coerced to bool"""
+    def test_bool_string_coerced(self):
+        """Boolean strings ("true"/"false", any case) are coerced to bool.
+
+        Required for for_each templating: Jinja renders Python booleans as the
+        strings "True"/"False", so bool fields must accept the string form.
+        """
+        assert res.Warehouse(name="MY_WH_T", auto_resume="true")._data.auto_resume is True
+        assert res.Warehouse(name="MY_WH_TC", auto_resume="True")._data.auto_resume is True
+        assert res.Warehouse(name="MY_WH_F", auto_resume="false")._data.auto_resume is False
+        assert res.Warehouse(name="MY_WH_FC", auto_resume="False")._data.auto_resume is False
+
+    def test_invalid_bool_string_rejected(self):
+        """Strings that aren't 'true'/'false' (any case) still raise TypeError"""
+        for bad in ("yes", "1", "", "truthy"):
+            with pytest.raises(TypeError):
+                res.Warehouse(name="MY_WH", auto_resume=bad)
+
+    def test_bool_passthrough(self):
+        """Native bool values pass through unchanged"""
+        assert res.Warehouse(name="MY_WH_T", auto_resume=True)._data.auto_resume is True
+        assert res.Warehouse(name="MY_WH_F", auto_resume=False)._data.auto_resume is False
+
+    def test_int_not_coerced_to_bool(self):
+        """Raw ints aren't coerced to bool, even though 1/0 are truthy in Python"""
         with pytest.raises(TypeError):
-            res.Warehouse(name="MY_WH", auto_resume="true")
+            res.Warehouse(name="MY_WH", auto_resume=1)
 
     def test_list_of_wrong_type_rejected(self):
         """List containing wrong types is rejected"""

--- a/tests/test_for_each.py
+++ b/tests/test_for_each.py
@@ -924,3 +924,44 @@ class TestForEachMultipleResourceTypes:
             elif name == "reporting_wh":
                 assert auto_suspend == 300
                 assert comment == "Reporting queries"
+
+    def test_for_each_warehouse_with_bool_properties(self):
+        """Bool fields rendered via for_each templating coerce from string.
+
+        Regression: Jinja stringifies Python booleans as "True"/"False" during
+        for_each expansion, so bool fields like auto_resume / initially_suspended
+        must accept the string form.
+        """
+        config = {
+            "vars": [
+                {
+                    "name": "warehouses",
+                    "type": "list",
+                    "default": [
+                        {"name": "wh_on", "auto_resume": True, "initially_suspended": True},
+                        {"name": "wh_off", "auto_resume": False, "initially_suspended": False},
+                    ],
+                }
+            ],
+            "warehouses": [
+                {
+                    "for_each": "var.warehouses",
+                    "name": "{{ each.value.name }}",
+                    "auto_resume": "{{ each.value.auto_resume }}",
+                    "initially_suspended": "{{ each.value.initially_suspended }}",
+                }
+            ],
+        }
+        blueprint_config = collect_blueprint_config(config)
+        assert len(blueprint_config.resources) == 2
+
+        for resource in blueprint_config.resources:
+            name = resource.urn.fqn.name
+            if name == "wh_on":
+                assert resource._data.auto_resume is True
+                assert resource._data.initially_suspended is True
+            elif name == "wh_off":
+                assert resource._data.auto_resume is False
+                assert resource._data.initially_suspended is False
+            else:
+                pytest.fail(f"Unexpected warehouse name: {name}")


### PR DESCRIPTION
## Summary
- Fixes a bug where bool fields fail with `TypeError` when populated via `for_each` templating. Jinja renders Python `True`/`False` as the strings `"True"`/`"False"`, but `_coerce_resource_field` previously rejected any string for a bool field.
- Adds a bool branch to `_coerce_resource_field` accepting `"true"`/`"false"` in any case (covers both YAML-style `"true"` and Jinja-stringified `"True"`).
- Inverts the now-obsolete `test_bool_string_not_coerced` test and adds positive/negative/passthrough coverage plus a for_each end-to-end regression test.

## Reproduction
```yaml
vars:
  - name: warehouses
    type: list
    default:
      - name: dbt__prod__xs_wh
        warehouse_size: XSMALL
        auto_resume: true
        initially_suspended: true

warehouses:
  - for_each: var.warehouses
    name: "{{ each.value.name }}"
    warehouse_size: "{{ each.value.warehouse_size }}"
    auto_resume: "{{ each.value.auto_resume }}"
    initially_suspended: "{{ each.value.initially_suspended }}"
```
Before this change: `TypeError` on `auto_resume`/`initially_suspended`. After: bools coerce correctly.

## Test plan
- [x] `ruff check snowcap/` passes
- [x] `make typecheck` passes
- [x] `pytest --ignore=tests/integration` — 1368 passed
- [x] New tests: `test_bool_string_coerced`, `test_invalid_bool_string_rejected`, `test_bool_passthrough`, `test_int_not_coerced_to_bool`, `test_for_each_warehouse_with_bool_properties`