### PR TITLE
fix(tag): prevent malformed SQL when updating TagMaskingPolicyReference

### DIFF
--- a/snowcap/blueprint.py
+++ b/snowcap/blueprint.py
@@ -1991,6 +1991,8 @@ def sql_commands_for_change(
     elif isinstance(change, UpdateResource):
         props = Resource.props_for_resource_type(change.urn.resource_type, change.after)
         change_cmd = lifecycle.update_resource(change.urn, change.delta, props)
+        if change.urn.resource_type == ResourceType.TAG_MASKING_POLICY_REFERENCE:
+            after_change_cmd.append(lifecycle.create_tag_masking_policy_reference(change.urn, change.after, props))
     elif isinstance(change, DropResource):
         if transfer_owner:
             before_change_cmd.append(

--- a/snowcap/lifecycle.py
+++ b/snowcap/lifecycle.py
@@ -369,6 +369,24 @@ def update_account_parameter(urn: URN, data: dict, props: Props) -> str:
     return create_account_parameter(urn, data, props)
 
 
+def update_tag_masking_policy_reference(urn: URN, data: dict, props: Props) -> str:
+    """
+    Return the UNSET statement for a tag masking policy binding change.
+
+    A masking policy binding update requires two steps:
+        1. ALTER TAG <tag> UNSET MASKING POLICY <old_policy>  ← this function
+        2. ALTER TAG <tag> SET MASKING POLICY <new_policy>    ← emitted as after_change_cmd
+           in blueprint.sql_commands_for_change
+
+    Using urn.fqn directly would produce malformed SQL because
+    TagMaskingPolicyReference encodes the masking policy name as a URN query-string
+    param (TAG?masking_policy=POLICY), not as a plain SQL identifier.
+    """
+    tag_sql = fqn_to_sql(urn.fqn)
+    old_masking_policy = urn.fqn.params.get("masking_policy", "")
+    return tidy_sql("ALTER TAG", tag_sql, "UNSET MASKING POLICY", old_masking_policy)
+
+
 def update_event_table(urn: URN, data: dict, props: Props) -> str:
     new_urn = URN(ResourceType.TABLE, urn.fqn, urn.account_locator)
     return update__default(new_urn, data, props)

--- a/snowcap/resources/tag.py
+++ b/snowcap/resources/tag.py
@@ -177,6 +177,16 @@ class _TagMaskingPolicyReference(ResourceSpec):
     tag_name: str
     masking_policy_name: str
 
+    def __post_init__(self):
+        super().__post_init__()
+        # Normalize unquoted identifiers to lowercase so manifest values compare
+        # equal to what the data provider returns from INFORMATION_SCHEMA, which
+        # always lowercases unquoted Snowflake identifier components.
+        if self.tag_name and not any(self.tag_name.startswith(q) for q in ('"',)):
+            self.tag_name = self.tag_name.lower()
+        if self.masking_policy_name and not any(self.masking_policy_name.startswith(q) for q in ('"',)):
+            self.masking_policy_name = self.masking_policy_name.lower()
+
 
 class TagMaskingPolicyReference(Resource):
     """

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -36,6 +36,7 @@ from snowcap.lifecycle import (
     update_scanner_package,
     update_schema,
     update_table,
+    update_tag_masking_policy_reference,
     update_task,
     update_iceberg_table,
     drop_resource,
@@ -86,6 +87,17 @@ def make_fqn(name, database=None, schema=None, arg_types=None):
 def make_urn(resource_type, name, database=None, schema=None, account_locator="ABC123"):
     """Helper to create URN objects."""
     fqn = make_fqn(name, database, schema)
+    return URN(resource_type=resource_type, fqn=fqn, account_locator=account_locator)
+
+
+def make_urn_with_params(resource_type, name, database=None, schema=None, params=None, account_locator="ABC123"):
+    """Helper to create URN objects with FQN params (e.g. for TagMaskingPolicyReference)."""
+    fqn = FQN(
+        name=ResourceName(name),
+        database=ResourceName(database) if database else None,
+        schema=ResourceName(schema) if schema else None,
+        params=params or {},
+    )
     return URN(resource_type=resource_type, fqn=fqn, account_locator=account_locator)
 
 
@@ -1247,3 +1259,73 @@ class TestDropTagMaskingPolicyReference:
         result = drop_tag_masking_policy_reference(urn, data)
         assert "ALTER TAG GOVERNANCE_DB.TAGS.SENSITIVE" in result
         assert "UNSET MASKING POLICY SECURITY_DB.POLICIES.MASK_SENSITIVE" in result
+
+
+class TestUpdateTagMaskingPolicyReference:
+    """
+    Tests for update_tag_masking_policy_reference.
+
+    The bug: update__default interpolates urn.fqn into DDL, but
+    TagMaskingPolicyReference.fqn is in URN query-string form
+    (TAG?masking_policy=POLICY), producing malformed SQL:
+
+        ALTER TAG MASKING POLICY REFERENCE GOVERNANCE.TAGS.HR_PII?masking_policy=... SET
+
+    Snowflake rejects this with error 001003 (42000).
+
+    The fix emits valid DDL by extracting the tag name via fqn_to_sql (which
+    strips FQN params) and the old policy from urn.fqn.params.
+    """
+
+    def test_emits_unset_with_valid_sql(self):
+        """UNSET statement must not contain the '?masking_policy=' query-string suffix."""
+        urn = make_urn_with_params(
+            ResourceType.TAG_MASKING_POLICY_REFERENCE,
+            name="HR_PII",
+            database="GOVERNANCE",
+            schema="TAGS",
+            params={"masking_policy": "GOVERNANCE.POLICIES.MASK_HR_PII_TIMESTAMP_NTZ"},
+        )
+        data = {"masking_policy_name": "GOVERNANCE.POLICIES.MASK_HR_PII_STRING"}
+        props = MockProps("")
+        result = update_tag_masking_policy_reference(urn, data, props)
+
+        assert "?" not in result, f"malformed SQL contains '?': {result!r}"
+        assert "UNSET MASKING POLICY" in result
+        assert "GOVERNANCE.TAGS.HR_PII" in result
+        assert "GOVERNANCE.POLICIES.MASK_HR_PII_TIMESTAMP_NTZ" in result
+
+    def test_uses_old_policy_from_urn_params_for_unset(self):
+        """UNSET must reference the OLD masking policy (from urn.fqn.params), not the new one."""
+        old_policy = "MY_DB.MY_SCHEMA.MASK_PII_V1"
+        new_policy = "MY_DB.MY_SCHEMA.MASK_PII_V2"
+        urn = make_urn_with_params(
+            ResourceType.TAG_MASKING_POLICY_REFERENCE,
+            name="PII",
+            database="MY_DB",
+            schema="MY_SCHEMA",
+            params={"masking_policy": old_policy},
+        )
+        data = {"masking_policy_name": new_policy}
+        props = MockProps("")
+        result = update_tag_masking_policy_reference(urn, data, props)
+
+        assert old_policy in result
+        assert new_policy not in result
+        assert "UNSET MASKING POLICY" in result
+
+    def test_update_dispatched_via_update_resource(self):
+        """update_resource dispatcher must route TAG_MASKING_POLICY_REFERENCE to the dedicated handler."""
+        urn = make_urn_with_params(
+            ResourceType.TAG_MASKING_POLICY_REFERENCE,
+            name="PII",
+            database="MY_DB",
+            schema="MY_SCHEMA",
+            params={"masking_policy": "MY_DB.MY_SCHEMA.MASK_OLD"},
+        )
+        data = {"masking_policy_name": "MY_DB.MY_SCHEMA.MASK_NEW"}
+        props = MockProps("")
+        result = update_resource(urn, data, props)
+
+        assert "?" not in result, f"dispatcher produced malformed SQL: {result!r}"
+        assert "UNSET MASKING POLICY" in result

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -298,3 +298,41 @@ def test_user_type_fallback(caplog):
     assert user._data.type == UserType.SERVICE
 
 
+class TestTagMaskingPolicyReferenceNormalization:
+    """
+    Verify that _TagMaskingPolicyReference normalizes identifier case to lowercase.
+
+    The data provider (fetch_tag_masking_policy_reference) always returns lowercase
+    identifier strings.  Without normalization, a YAML manifest that uses uppercase
+    or mixed-case names would produce a case-sensitive delta against the remote state,
+    triggering a spurious UPDATE that generates malformed SQL via update__default.
+    """
+
+    def test_tag_name_normalized_to_lowercase(self):
+        ref = res.TagMaskingPolicyReference(
+            tag_name="GOVERNANCE.TAGS.HR_PII",
+            masking_policy_name="GOVERNANCE.POLICIES.MASK_HR_PII",
+        )
+        assert ref._data.tag_name == "governance.tags.hr_pii"
+
+    def test_masking_policy_name_normalized_to_lowercase(self):
+        ref = res.TagMaskingPolicyReference(
+            tag_name="governance.tags.hr_pii",
+            masking_policy_name="GOVERNANCE.POLICIES.MASK_HR_PII_TIMESTAMP_NTZ",
+        )
+        assert ref._data.masking_policy_name == "governance.policies.mask_hr_pii_timestamp_ntz"
+
+    def test_mixed_case_matches_lowercase_remote_state(self):
+        """YAML with mixed case should produce the same data dict as the remote state."""
+        ref_mixed = res.TagMaskingPolicyReference(
+            tag_name="Governance.Tags.HR_PII",
+            masking_policy_name="Governance.Policies.Mask_HR_PII",
+        )
+        ref_lower = res.TagMaskingPolicyReference(
+            tag_name="governance.tags.hr_pii",
+            masking_policy_name="governance.policies.mask_hr_pii",
+        )
+        assert ref_mixed._data.tag_name == ref_lower._data.tag_name
+        assert ref_mixed._data.masking_policy_name == ref_lower._data.masking_policy_name
+
+


### PR DESCRIPTION
## Summary

`update__default` interpolates `urn.fqn` directly into DDL. For `TagMaskingPolicyReference`, `urn.fqn` renders in URN query-string form (`TAG?masking_policy=POLICY`), not as a valid SQL identifier. This produces a SQL compilation error that crashes any plan that contains a `TagMaskingPolicyReference` update.

## Reproducer

Given the following YAML:

```yaml
tag_masking_policy_references:
  - tag_name: GOVERNANCE.TAGS.HR_PII
    masking_policy_name: GOVERNANCE.POLICIES.MASK_HR_PII_TIMESTAMP_NTZ
```

When snowcap computes an UPDATE plan for this resource (e.g. triggered by a case-mismatch between the YAML and what Snowflake returns — see Fix B below), it emits:

```sql
ALTER TAG MASKING POLICY REFERENCE GOVERNANCE.TAGS.HR_PII?masking_policy=GOVERNANCE.POLICIES.MASK_HR_PII_TIMESTAMP_NTZ SET
```

Snowflake rejects this with:

```
001003 (42000): SQL compilation error: syntax error line 1 at position 18 unexpected 'POLICY'
```

## Root cause

`update_resource` dispatches by resource label. `TagMaskingPolicyReference` had no dedicated handler, so it fell through to `update__default`, which uses `urn.fqn` in the DDL template. `tag_masking_policy_reference_fqn` encodes the masking policy name as a URN query-string param (`params={"masking_policy": ...}`), and `FQN.__str__` appends `?masking_policy=<value>` to the identifier string — invalid in any `ALTER TAG` statement.

There is a secondary issue: the data provider normalizes identifiers to lowercase (via `INFORMATION_SCHEMA` results), but the manifest stores whatever case the user wrote in YAML. Because `FQN.__eq__` uses `ResourceName` (case-insensitive) for name/database/schema but plain dict equality for params, URNs with the same masking policy in different cases match. However, `_diff_resource_data` does a plain string `!=` comparison, so the `tag_name` field differs in case → generates a spurious delta → triggers the broken UPDATE path.

## What the fix does

**Fix A (required — malformed SQL):**
- Adds `update_tag_masking_policy_reference` in `lifecycle.py`. It extracts the tag name via `fqn_to_sql(urn.fqn)` (which correctly omits FQN params) and the old policy from `urn.fqn.params["masking_policy"]`, emitting a valid `ALTER TAG <tag> UNSET MASKING POLICY <old_policy>` as the primary command.
- Adds a special case in `blueprint.sql_commands_for_change` to append `ALTER TAG <tag> SET MASKING POLICY <new_policy>` as `after_change_cmd`, matching the two-statement pattern Snowflake requires for binding changes (modelled after the existing `SCANNER_PACKAGE` pattern).

**Fix B (nice-to-have — spurious UPDATE prevention):**
- Adds `__post_init__` to `_TagMaskingPolicyReference` that normalizes `tag_name` and `masking_policy_name` to lowercase, matching what `fetch_tag_masking_policy_reference` returns from `INFORMATION_SCHEMA`. This eliminates the case-sensitive delta that triggers the UPDATE in the first place.

## Test plan

- Added `TestUpdateTagMaskingPolicyReference` in `tests/test_lifecycle.py`:
  - Asserts the generated SQL does not contain `?` (the query-string suffix)
  - Asserts the UNSET statement references the **old** policy (from `urn.fqn.params`), not the new one
  - Asserts `update_resource` dispatcher routes to the new handler
- Added `TestTagMaskingPolicyReferenceNormalization` in `tests/test_resources.py`:
  - Asserts uppercase YAML values are lowercased in `_data`
  - Asserts mixed-case manifest matches lowercase remote state

All 1511 unit tests pass locally (`pytest tests/ -m "not requires_snowflake" --ignore=tests/integration`).