### PR TITLE
fix(lifecycle): apply ALL fields in update__default, not just popitem()

### DIFF
--- a/snowcap/lifecycle.py
+++ b/snowcap/lifecycle.py
@@ -338,22 +338,49 @@ def update_resource(urn: URN, data: dict, props: Props) -> str:
 
 
 def update__default(urn: URN, data: dict, props: Props) -> str:
-    attr, new_value = data.popitem()
-    attr = attr.lower()
-    if new_value is None:
-        return tidy_sql("ALTER", urn.resource_type, urn.fqn, "UNSET", attr)
-    elif attr == "name":
-        return tidy_sql("ALTER", urn.resource_type, urn.fqn, "RENAME TO", new_value)
-    elif attr == "owner":
-        raise NotImplementedError
-    else:
-        return tidy_sql(
-            "ALTER",
-            urn.resource_type,
-            urn.fqn,
-            "SET",
-            props.render({attr: new_value}),
+    # Render every field in the delta into a single ALTER statement.
+    # The previous implementation called `data.popitem()` and silently
+    # discarded all other fields, so multi-field deltas (e.g. rotating
+    # rsa_public_key + bumping comment on a USER in one apply) only
+    # updated whichever field popitem happened to return.
+    #
+    # Snowflake's ALTER ... SET p1 = v1, p2 = v2 syntax accepts multiple
+    # property assignments in one statement, and Props.render(data) already
+    # iterates all keys — so the SET case is the common one and combines
+    # cleanly. UNSET (value is None) must be a separate statement because
+    # Snowflake disallows mixing SET and UNSET in one ALTER. RENAME TO and
+    # owner remain as their own clauses (no Snowflake syntax exists to
+    # combine them with SET/UNSET in one statement).
+
+    if "name" in data and len(data) > 1:
+        raise NotImplementedError(
+            f"update__default cannot combine 'name' (RENAME TO) with other fields "
+            f"in one ALTER for {urn}; got delta keys {sorted(data.keys())!r}"
         )
+    if "owner" in data and len(data) > 1:
+        raise NotImplementedError(
+            f"update__default cannot combine 'owner' with other fields "
+            f"in one ALTER for {urn}; got delta keys {sorted(data.keys())!r}"
+        )
+    if "name" in data:
+        return tidy_sql("ALTER", urn.resource_type, urn.fqn, "RENAME TO", data["name"])
+    if "owner" in data:
+        raise NotImplementedError
+
+    unset_attrs = [attr.lower() for attr, v in data.items() if v is None]
+    set_data = {attr: v for attr, v in data.items() if v is not None}
+    if unset_attrs and set_data:
+        # Snowflake rejects mixing SET and UNSET in one ALTER. The caller's
+        # diff layer is expected to keep these in separate change records,
+        # so reaching here means something upstream batched them together.
+        raise NotImplementedError(
+            f"update__default cannot mix SET and UNSET attrs in one ALTER for {urn}; "
+            f"got SET={sorted(set_data.keys())!r} UNSET={sorted(unset_attrs)!r}"
+        )
+
+    if unset_attrs:
+        return tidy_sql("ALTER", urn.resource_type, urn.fqn, "UNSET", ", ".join(unset_attrs))
+    return tidy_sql("ALTER", urn.resource_type, urn.fqn, "SET", props.render(set_data))
 
 
 def update_masking_policy(urn: URN, data: dict, props: Props) -> str:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -690,6 +690,51 @@ class TestUpdateDefault:
         with pytest.raises(NotImplementedError):
             update__default(urn, data, props)
 
+    def test_set_multiple_properties_in_one_statement(self):
+        """Regression: multi-field SET deltas must update all fields, not just one.
+
+        Previously update__default called data.popitem() and silently dropped
+        every field except the one popitem returned. This caused security-
+        sensitive rotations (e.g. rsa_public_key + comment on a user) to land
+        the comment but leave the old key in place, with the apply summary
+        still reporting "1 updated" and no error/warning.
+        """
+        urn = make_urn(ResourceType.USER, "MY_USER")
+        data = {"rsa_public_key": "MIIBNEW...", "comment": "rotated 2026-05-31"}
+        props = MockProps("RSA_PUBLIC_KEY = $$MIIBNEW...$$ COMMENT = $$rotated 2026-05-31$$")
+        result = update__default(urn, data, props)
+        assert result.startswith("ALTER USER MY_USER SET ")
+        assert "RSA_PUBLIC_KEY = $$MIIBNEW...$$" in result
+        assert "COMMENT = $$rotated 2026-05-31$$" in result
+        # Must be a single ALTER statement (no semicolons → no multi-statement
+        # risk with snowflake-connector-python's default MULTI_STATEMENT_COUNT=1).
+        assert result.count("ALTER ") == 1
+        assert ";" not in result
+
+    def test_unset_multiple_properties_in_one_statement(self):
+        """Multi-field UNSET deltas combine into one ALTER ... UNSET col1, col2."""
+        urn = make_urn(ResourceType.WAREHOUSE, "MY_WH")
+        data = {"comment": None, "tag": None}
+        props = MockProps("")
+        result = update__default(urn, data, props)
+        assert result == "ALTER WAREHOUSE MY_WH UNSET comment, tag"
+
+    def test_mixed_set_and_unset_raises(self):
+        """SET and UNSET cannot share an ALTER statement in Snowflake."""
+        urn = make_urn(ResourceType.WAREHOUSE, "MY_WH")
+        data = {"size": "LARGE", "comment": None}
+        props = MockProps("SIZE = 'LARGE'")
+        with pytest.raises(NotImplementedError, match="mix SET and UNSET"):
+            update__default(urn, data, props)
+
+    def test_rename_combined_with_other_fields_raises(self):
+        """RENAME TO has its own ALTER syntax and can't combine with SET."""
+        urn = make_urn(ResourceType.WAREHOUSE, "MY_WH")
+        data = {"name": "NEW_WH", "comment": "renamed"}
+        props = MockProps("")
+        with pytest.raises(NotImplementedError, match="'name'"):
+            update__default(urn, data, props)
+
 
 # ============================================================================
 # Test specialized update functions


### PR DESCRIPTION
## Bug

`lifecycle.update__default()` calls `data.popitem()` and renders SQL for only that single attr. When a resource's update delta contains multiple changed fields, all but one are silently dropped — no error, no warning, the apply summary still says "1 updated".

### Reproduction (a USER rotation that motivated this)

```yaml
users:
  - name: SVC_DEMO
    rsa_public_key: |
      MIIB...   # ← change
    comment: "rotated YYYY-MM-DD"   # ← change
```

`snowcap apply`'s diff display correctly shows BOTH `rsa_public_key` AND `comment` under Before/After (so the diff layer sees both). The post-apply Snowflake state has only **one** field updated — the last one in the delta dict, since Python 3.7+'s `popitem()` is LIFO.

Verified end-to-end against live Snowflake:

| Field | Before | After (expected) | After (actual) |
|---|---|---|---|
| `comment` | "old" | "new" | "new" ✅ |
| `rsa_public_key` | `...rY3ErOOki4...` | `...m7tOkz...` | `...rY3ErOOki4...` ❌ |

`snowcap apply` reported `Applied: N created, 1 updated` and emitted no warning or error.

## Root cause

[`snowcap/lifecycle.py:340`](https://github.com/datacoves/snowcap/blob/main/snowcap/lifecycle.py#L340)

```python
def update__default(urn: URN, data: dict, props: Props) -> str:
    attr, new_value = data.popitem()   # ← only ever handles ONE field
    ...
```

`Props.render(data)` at [`snowcap/props.py:104`](https://github.com/datacoves/snowcap/blob/main/snowcap/props.py#L104) **already iterates every key in `data` and renders each prop**, so multi-prop rendering is supported at the render layer. The bug is purely the `popitem()` filter in `update__default`.

## Fix

- Drop the `popitem()` filter; pass the full delta through `props.render()`.
- Snowflake's `ALTER ... SET p1 = v1, p2 = v2` syntax accepts multiple property assignments in one statement, which is what the new code emits.
- UNSET (value is None) and SET cannot share an ALTER in Snowflake → keep them separate (one `ALTER ... UNSET col1, col2`, one `ALTER ... SET k1 = v1, k2 = v2`). If a delta mixes both, raise `NotImplementedError` (the diff layer should keep them in separate change records; that path isn't reached by the SVC_GHA_DBT_CI rotation).
- `RENAME TO` and `owner` retain their special-case isolation — no Snowflake syntax exists to combine them with SET/UNSET in one ALTER. If combined with other fields in one delta, raise `NotImplementedError`.

## Tests

4 new regression tests in `tests/test_lifecycle.py::TestUpdateDefault`:

- `test_set_multiple_properties_in_one_statement` — the exact `rsa_public_key + comment` case, asserting both end up in a single ALTER USER SET statement and that no semicolons are present (so we don't trip over `snowflake-connector-python`'s default `MULTI_STATEMENT_COUNT=1`)
- `test_unset_multiple_properties_in_one_statement` — `ALTER ... UNSET col1, col2`
- `test_mixed_set_and_unset_raises` — Snowflake's syntax disallows it
- `test_rename_combined_with_other_fields_raises` — same rationale

All existing `TestUpdateDefault` tests still pass.

```
$ pytest tests/test_lifecycle.py
106 passed in 4.07s

$ pytest tests/ --ignore=tests/integration
1515 passed, 0 failed
```

## Impact

Any rotation that touches a multi-attribute resource silently fails for all but one field. The security-sensitive `rsa_public_key` case is the loudest, because:

1. The apply diff shows both Before/After columns populated
2. The "Applied" summary reports a count consistent with success
3. The actual Snowflake state silently retains the old key
4. Any pre-rotation GH-secret/keystore update (matching the new key) then fails authentication because Snowflake holds the old key

Took an hour to root-cause this evening because every external signal suggested success.

## Notes

- Issues are disabled on this repo, so this PR contains the bug report and the fix.
- I'll keep our consumer (BCS) pinned to a fork branch with this commit cherry-picked until this lands upstream. Happy to revise the fix surface (e.g. return `list[str]` instead of joining strings) if you'd prefer.