### PR TITLE
Add Snowflake Gen2 warehouse support

### DIFF
--- a/docs/resources/warehouse.md
+++ b/docs/resources/warehouse.md
@@ -12,30 +12,6 @@ A virtual warehouse, often referred to simply as a "warehouse", is a cluster of 
 
 ## Examples
 
-### YAML
-
-```yaml
-warehouses:
-  - name: some_warehouse
-    owner: SYSADMIN
-    warehouse_type: STANDARD
-    warehouse_size: XSMALL
-    max_cluster_count: 10
-    min_cluster_count: 1
-    scaling_policy: STANDARD
-    auto_suspend: 600
-    auto_resume: true
-    initially_suspended: false
-    comment: This is a test warehouse
-    enable_query_acceleration: false
-    query_acceleration_max_scale_factor: 1
-    max_concurrency_level: 8
-    statement_queued_timeout_in_seconds: 0
-    statement_timeout_in_seconds: 172800
-    tags:
-      env: test
-```
-
 ### Python
 
 ```python
@@ -44,6 +20,8 @@ warehouse = Warehouse(
     owner="SYSADMIN",
     warehouse_type="STANDARD",
     warehouse_size="XSMALL",
+    generation="2",
+    resource_constraint="STANDARD_GEN_2",
     max_cluster_count=10,
     min_cluster_count=1,
     scaling_policy="STANDARD",
@@ -62,25 +40,53 @@ warehouse = Warehouse(
 ```
 
 
+### YAML
+
+```yaml
+warehouses:
+  - name: some_warehouse
+    owner: SYSADMIN
+    warehouse_type: STANDARD
+    warehouse_size: XSMALL
+    generation: "2"
+    resource_constraint: STANDARD_GEN_2
+    max_cluster_count: 10
+    min_cluster_count: 1
+    scaling_policy: STANDARD
+    auto_suspend: 600
+    auto_resume: true
+    initially_suspended: false
+    resource_monitor: null
+    comment: This is a test warehouse
+    enable_query_acceleration: false
+    query_acceleration_max_scale_factor: 1
+    max_concurrency_level: 8
+    statement_queued_timeout_in_seconds: 0
+    statement_timeout_in_seconds: 172800
+    tags:
+      env: test
+```
+
+
 ## Fields
 
 * `name` (string, required) - The name of the warehouse.
 * `owner` (string) - The owner of the warehouse. Defaults to "SYSADMIN".
-* `warehouse_type` (string or WarehouseType) - The type of the warehouse, either STANDARD or SNOWPARK-OPTIMIZED. Defaults to STANDARD.
-* `warehouse_size` (string or WarehouseSize) - The size of the warehouse which defines the compute and storage capacity.
+* `warehouse_type` (string or [WarehouseType](warehouse_type.md)) - The type of the warehouse, either STANDARD or SNOWPARK-OPTIMIZED. Defaults to STANDARD.
+* `warehouse_size` (string or [WarehouseSize](warehouse_size.md)) - The size of the warehouse which defines the compute and storage capacity.
+* `generation` (string or [WarehouseGeneration](warehouse_generation.md)) - The standard warehouse generation, either "1" or "2".
+* `resource_constraint` (string or [WarehouseResourceConstraint](warehouse_resource_constraint.md)) - The warehouse resource constraint, either STANDARD_GEN_1/2 for standard warehouses or MEMORY_* for Snowpark-optimized warehouses.
 * `max_cluster_count` (int) - The maximum number of clusters for the warehouse.
 * `min_cluster_count` (int) - The minimum number of clusters for the warehouse.
-* `scaling_policy` (string or WarehouseScalingPolicy) - The policy that defines how the warehouse scales.
+* `scaling_policy` (string or [WarehouseScalingPolicy](warehouse_scaling_policy.md)) - The policy that defines how the warehouse scales.
 * `auto_suspend` (int) - The time in seconds of inactivity after which the warehouse is automatically suspended.
 * `auto_resume` (bool) - Whether the warehouse should automatically resume when queries are submitted.
 * `initially_suspended` (bool) - Whether the warehouse should start in a suspended state.
 * `resource_monitor` (string or [ResourceMonitor](resource_monitor.md)) - The resource monitor that tracks the warehouse's credit usage and other metrics.
 * `comment` (string) - A comment about the warehouse.
-* `enable_query_acceleration` (bool) - Whether query acceleration is enabled to improve performance.
-* `query_acceleration_max_scale_factor` (int) - The maximum scale factor for query acceleration.
+* `enable_query_acceleration` (bool) - Whether query acceleration is enabled to improve performance. If omitted, Snowflake's default applies.
+* `query_acceleration_max_scale_factor` (int) - The maximum scale factor for query acceleration. If omitted, Snowflake's default applies.
 * `max_concurrency_level` (int) - The maximum number of concurrent queries that the warehouse can handle.
 * `statement_queued_timeout_in_seconds` (int) - The time in seconds a statement can be queued before it times out.
 * `statement_timeout_in_seconds` (int) - The time in seconds a statement can run before it times out.
 * `tags` (dict) - Tags for the warehouse.
-
-

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -386,6 +386,17 @@ def options_result_to_list(options_result):
     return [option.strip(" ") for option in options_result.split(",")]
 
 
+def _normalize_snowflake_optional(value, upper: bool = False):
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        if value == "" or value.lower() == "null":
+            return None
+        return value.upper() if upper else value
+    return value
+
+
 def remove_none_values(d):
     new_dict = {}
     for k, v in d.items():
@@ -3149,26 +3160,39 @@ def fetch_warehouse(session: SnowflakeConnection, fqn: FQN, include_params: bool
         statement_queued_timeout = None
         statement_timeout = None
 
-    resource_monitor = None if data["resource_monitor"] == "null" else data["resource_monitor"]
+    resource_monitor = _normalize_snowflake_optional(data.get("resource_monitor"))
+    warehouse_type = _normalize_snowflake_optional(data["type"], upper=True)
+    generation = _normalize_snowflake_optional(data.get("generation"))
+    if generation is not None:
+        generation = str(generation)
+    resource_constraint = _normalize_snowflake_optional(data.get("resource_constraint"), upper=True)
+
+    if warehouse_type == "STANDARD":
+        if resource_constraint is None and generation in {"1", "2"}:
+            resource_constraint = f"STANDARD_GEN_{generation}"
+        elif generation is None and resource_constraint in {"STANDARD_GEN_1", "STANDARD_GEN_2"}:
+            generation = resource_constraint[-1]
 
     # Enterprise edition features
-    query_accel = data.get("enable_query_acceleration")
-    if query_accel:
-        query_accel = query_accel == "true"
-    else:
-        query_accel = False
+    query_accel = _normalize_snowflake_optional(data.get("enable_query_acceleration"))
+    if query_accel is not None:
+        query_accel = str(query_accel).lower() == "true"
 
     warehouse_dict = {
         "name": _quote_snowflake_identifier(data["name"]),
         "owner": _get_owner_identifier(data),
-        "warehouse_type": data["type"],
+        "warehouse_type": warehouse_type,
         "warehouse_size": str(WarehouseSize(data["size"])),
+        "generation": generation,
+        "resource_constraint": resource_constraint,
         "auto_suspend": data["auto_suspend"],
         "auto_resume": data["auto_resume"] == "true",
         "comment": data["comment"] or None,
         "resource_monitor": resource_monitor,
         "enable_query_acceleration": query_accel,
-        "query_acceleration_max_scale_factor": data.get("query_acceleration_max_scale_factor", None),
+        "query_acceleration_max_scale_factor": _normalize_snowflake_optional(
+            data.get("query_acceleration_max_scale_factor", None)
+        ),
         "max_cluster_count": data.get("max_cluster_count", None),
         "min_cluster_count": data.get("min_cluster_count", None),
         "scaling_policy": data.get("scaling_policy", None),

--- a/snowcap/resources/__init__.py
+++ b/snowcap/resources/__init__.py
@@ -71,7 +71,7 @@ from .tag import Tag, TagMaskingPolicyReference, TagReference
 from .task import Task
 from .user import User
 from .view import View
-from .warehouse import Warehouse
+from .warehouse import Warehouse, WarehouseGeneration, WarehouseResourceConstraint
 
 __all__ = [
     "Account",
@@ -154,4 +154,6 @@ __all__ = [
     "View",
     "ViewStream",
     "Warehouse",
+    "WarehouseGeneration",
+    "WarehouseResourceConstraint",
 ]

--- a/snowcap/resources/warehouse.py
+++ b/snowcap/resources/warehouse.py
@@ -29,12 +29,55 @@ class WarehouseScalingPolicy(ParseableEnum):
     ECONOMY = "ECONOMY"
 
 
+class WarehouseGeneration(ParseableEnum):
+    GEN1 = "1"
+    GEN2 = "2"
+
+    @classmethod
+    def synonyms(cls):
+        return {
+            "GEN1": "GEN1",
+            "GEN2": "GEN2",
+        }
+
+
+class WarehouseResourceConstraint(ParseableEnum):
+    STANDARD_GEN_1 = "STANDARD_GEN_1"
+    STANDARD_GEN_2 = "STANDARD_GEN_2"
+    MEMORY_1X = "MEMORY_1X"
+    MEMORY_1X_X86 = "MEMORY_1X_X86"
+    MEMORY_16X = "MEMORY_16X"
+    MEMORY_16X_X86 = "MEMORY_16X_X86"
+    MEMORY_64X = "MEMORY_64X"
+    MEMORY_64X_X86 = "MEMORY_64X_X86"
+
+
+STANDARD_RESOURCE_CONSTRAINTS = {
+    WarehouseResourceConstraint.STANDARD_GEN_1,
+    WarehouseResourceConstraint.STANDARD_GEN_2,
+}
+SNOWPARK_RESOURCE_CONSTRAINTS = {
+    WarehouseResourceConstraint.MEMORY_1X,
+    WarehouseResourceConstraint.MEMORY_1X_X86,
+    WarehouseResourceConstraint.MEMORY_16X,
+    WarehouseResourceConstraint.MEMORY_16X_X86,
+    WarehouseResourceConstraint.MEMORY_64X,
+    WarehouseResourceConstraint.MEMORY_64X_X86,
+}
+GENERATION_RESOURCE_CONSTRAINTS = {
+    WarehouseGeneration.GEN1: WarehouseResourceConstraint.STANDARD_GEN_1,
+    WarehouseGeneration.GEN2: WarehouseResourceConstraint.STANDARD_GEN_2,
+}
+
+
 @dataclass(unsafe_hash=True)
 class _Warehouse(ResourceSpec):
     name: ResourceName
     owner: Role = "SYSADMIN"
     warehouse_type: WarehouseType = WarehouseType.STANDARD
     warehouse_size: WarehouseSize = WarehouseSize.XSMALL
+    generation: Optional[WarehouseGeneration] = None
+    resource_constraint: Optional[WarehouseResourceConstraint] = None
     max_cluster_count: int = field(
         default=1,
         metadata={"edition": {AccountEdition.ENTERPRISE, AccountEdition.BUSINESS_CRITICAL}},
@@ -52,17 +95,43 @@ class _Warehouse(ResourceSpec):
     initially_suspended: bool = field(default=False, metadata={"fetchable": False})
     resource_monitor: ResourceMonitor = None
     comment: str = None
-    enable_query_acceleration: bool = field(
-        default=False,
+    enable_query_acceleration: Optional[bool] = field(
+        default=None,
         metadata={"edition": {AccountEdition.ENTERPRISE, AccountEdition.BUSINESS_CRITICAL}},
     )
-    query_acceleration_max_scale_factor: int = field(
-        default=8,
+    query_acceleration_max_scale_factor: Optional[int] = field(
+        default=None,
         metadata={"edition": {AccountEdition.ENTERPRISE, AccountEdition.BUSINESS_CRITICAL}},
     )
     max_concurrency_level: Optional[int] = None  # Uses Snowflake default (8) if not specified
     statement_queued_timeout_in_seconds: Optional[int] = None  # Uses Snowflake default (0) if not specified
     statement_timeout_in_seconds: Optional[int] = None  # Uses Snowflake default (172800) if not specified
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.generation is not None and self.warehouse_type != WarehouseType.STANDARD:
+            raise ValueError("generation is only valid for STANDARD warehouses")
+
+        if self.resource_constraint is not None:
+            if self.warehouse_type == WarehouseType.STANDARD:
+                if self.resource_constraint not in STANDARD_RESOURCE_CONSTRAINTS:
+                    raise ValueError("STANDARD warehouses only support STANDARD_GEN_1 or STANDARD_GEN_2")
+            elif self.warehouse_type == WarehouseType.SNOWPARK_OPTIMIZED:
+                if self.resource_constraint not in SNOWPARK_RESOURCE_CONSTRAINTS:
+                    raise ValueError("SNOWPARK-OPTIMIZED warehouses only support MEMORY_* resource constraints")
+
+        if self.generation is not None and self.resource_constraint is not None:
+            expected_constraint = GENERATION_RESOURCE_CONSTRAINTS[self.generation]
+            if self.resource_constraint != expected_constraint:
+                raise ValueError("generation and resource_constraint must describe the same warehouse generation")
+
+        uses_standard_gen2 = (
+            self.generation == WarehouseGeneration.GEN2
+            or self.resource_constraint == WarehouseResourceConstraint.STANDARD_GEN_2
+        )
+        if uses_standard_gen2 and self.warehouse_size in {WarehouseSize.X5LARGE, WarehouseSize.X6LARGE}:
+            raise ValueError("Gen2 standard warehouses do not support X5LARGE or X6LARGE sizes")
 
 
 class Warehouse(NamedResource, TaggableResource, Resource):
@@ -78,6 +147,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         owner (string): The owner of the warehouse. Defaults to "SYSADMIN".
         warehouse_type (string or WarehouseType): The type of the warehouse, either STANDARD or SNOWPARK-OPTIMIZED. Defaults to STANDARD.
         warehouse_size (string or WarehouseSize): The size of the warehouse which defines the compute and storage capacity.
+        generation (string or WarehouseGeneration): The standard warehouse generation, either "1" or "2".
+        resource_constraint (string or WarehouseResourceConstraint): The warehouse resource constraint, either STANDARD_GEN_1/2 for standard warehouses or MEMORY_* for Snowpark-optimized warehouses.
         max_cluster_count (int): The maximum number of clusters for the warehouse.
         min_cluster_count (int): The minimum number of clusters for the warehouse.
         scaling_policy (string or WarehouseScalingPolicy): The policy that defines how the warehouse scales.
@@ -86,8 +157,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         initially_suspended (bool): Whether the warehouse should start in a suspended state.
         resource_monitor (string or ResourceMonitor): The resource monitor that tracks the warehouse's credit usage and other metrics.
         comment (string): A comment about the warehouse.
-        enable_query_acceleration (bool): Whether query acceleration is enabled to improve performance.
-        query_acceleration_max_scale_factor (int): The maximum scale factor for query acceleration.
+        enable_query_acceleration (bool): Whether query acceleration is enabled to improve performance. If omitted, Snowflake's default applies.
+        query_acceleration_max_scale_factor (int): The maximum scale factor for query acceleration. If omitted, Snowflake's default applies.
         max_concurrency_level (int): The maximum number of concurrent queries that the warehouse can handle.
         statement_queued_timeout_in_seconds (int): The time in seconds a statement can be queued before it times out.
         statement_timeout_in_seconds (int): The time in seconds a statement can run before it times out.
@@ -101,6 +172,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
             owner="SYSADMIN",
             warehouse_type="STANDARD",
             warehouse_size="XSMALL",
+            generation="2",
+            resource_constraint="STANDARD_GEN_2",
             max_cluster_count=10,
             min_cluster_count=1,
             scaling_policy="STANDARD",
@@ -126,6 +199,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
             owner: SYSADMIN
             warehouse_type: STANDARD
             warehouse_size: XSMALL
+            generation: "2"
+            resource_constraint: STANDARD_GEN_2
             max_cluster_count: 10
             min_cluster_count: 1
             scaling_policy: STANDARD
@@ -149,6 +224,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         _start_token="WITH",
         warehouse_type=EnumProp("warehouse_type", WarehouseType, quoted=True),
         warehouse_size=EnumProp("warehouse_size", WarehouseSize),
+        generation=EnumProp("GENERATION", WarehouseGeneration, quoted=True),
+        resource_constraint=EnumProp("RESOURCE_CONSTRAINT", WarehouseResourceConstraint),
         max_cluster_count=IntProp("max_cluster_count"),
         min_cluster_count=IntProp("min_cluster_count"),
         scaling_policy=EnumProp("scaling_policy", WarehouseScalingPolicy),
@@ -173,6 +250,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         owner: str = "SYSADMIN",
         warehouse_type: str = "STANDARD",
         warehouse_size: str = "XSMALL",
+        generation: str = None,
+        resource_constraint: str = None,
         max_cluster_count: int = 1,
         min_cluster_count: int = 1,
         scaling_policy: str = "STANDARD",
@@ -181,8 +260,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         initially_suspended: bool = False,
         resource_monitor: Union[ResourceMonitor, str, None] = None,
         comment: str = None,
-        enable_query_acceleration: bool = False,
-        query_acceleration_max_scale_factor: int = 8,
+        enable_query_acceleration: Optional[bool] = None,
+        query_acceleration_max_scale_factor: Optional[int] = None,
         max_concurrency_level: int = None,
         statement_queued_timeout_in_seconds: int = None,
         statement_timeout_in_seconds: int = None,
@@ -195,6 +274,8 @@ class Warehouse(NamedResource, TaggableResource, Resource):
             owner=owner,
             warehouse_type=warehouse_type,
             warehouse_size=warehouse_size,
+            generation=generation,
+            resource_constraint=resource_constraint,
             max_cluster_count=max_cluster_count,
             min_cluster_count=min_cluster_count,
             scaling_policy=scaling_policy,

--- a/tests/fixtures/json/warehouse.json
+++ b/tests/fixtures/json/warehouse.json
@@ -3,6 +3,8 @@
     "owner": "SYSADMIN",
     "warehouse_type": "STANDARD",
     "warehouse_size": "XSMALL",
+    "generation": "2",
+    "resource_constraint": "STANDARD_GEN_2",
     "max_cluster_count": 1,
     "min_cluster_count": 1,
     "scaling_policy": "STANDARD",

--- a/tests/fixtures/sql/warehouse.sql
+++ b/tests/fixtures/sql/warehouse.sql
@@ -3,6 +3,8 @@ CREATE WAREHOUSE IF NOT EXISTS XSMALL_WH
     WITH
     WAREHOUSE_SIZE = 'XSMALL'
     WAREHOUSE_TYPE = 'STANDARD'
+    GENERATION = '2'
+    RESOURCE_CONSTRAINT = STANDARD_GEN_2
     AUTO_SUSPEND = 60
     AUTO_RESUME = FALSE
     initially_suspended = true
@@ -17,8 +19,8 @@ CREATE WAREHOUSE IF NOT EXISTS XSMALL_WH
 CREATE WAREHOUSE lowercase_wh
 warehouse_size = x6large
 warehouse_type = snowpark-optimized
+resource_constraint = memory_16x_x86
 scaling_policy = economy
 initially_suspended = true
 ;
-
 

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -771,6 +771,39 @@ def test_blueprint_warehouse_scaling_policy_doesnt_render_in_standard_edition(se
     assert "scaling_policy" not in sql[2]
 
 
+def test_blueprint_warehouse_generation_and_resource_constraint_update(session_ctx):
+    wh_urn = parse_URN("urn::ABCD123:warehouse/WH")
+    remote_state = {
+        parse_URN("urn::ABCD123:account/ACCOUNT"): {},
+        wh_urn: res.Warehouse(
+            name="WH",
+            generation="1",
+            resource_constraint="STANDARD_GEN_1",
+        ).to_dict(),
+    }
+    blueprint = Blueprint(
+        resources=[
+            res.Warehouse(
+                name="WH",
+                generation="2",
+                resource_constraint="STANDARD_GEN_2",
+            )
+        ]
+    )
+    manifest = blueprint.generate_manifest(session_ctx)
+
+    plan = diff(remote_state, manifest)
+    assert len(plan) == 1
+    wh_change = plan[0]
+    assert wh_change.delta == {
+        "generation": "2",
+        "resource_constraint": "STANDARD_GEN_2",
+    }
+
+    sql = flatten_sql_commands(compile_plan_to_sql(session_ctx, plan))
+    assert "ALTER WAREHOUSE WH SET GENERATION = '2' RESOURCE_CONSTRAINT = STANDARD_GEN_2" in sql
+
+
 def test_blueprint_scope_config():
 
     bc = BlueprintConfig(

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -33,6 +33,7 @@ from snowcap.data_provider import (
     remove_none_values,
     # Dispatcher functions
     fetch_resource,
+    fetch_warehouse,
     list_resource,
     list_account_scoped_resource,
     list_schema_scoped_resource,
@@ -639,6 +640,101 @@ class TestFetchResource:
 
         with pytest.raises(ProgrammingError):
             fetch_resource(mock_session, urn)
+
+
+def _warehouse_show_row(**overrides):
+    row = {
+        "name": "WH",
+        "owner": "SYSADMIN",
+        "owner_role_type": "ROLE",
+        "type": "STANDARD",
+        "size": "X-SMALL",
+        "auto_suspend": 600,
+        "auto_resume": "true",
+        "comment": "",
+        "resource_monitor": "null",
+    }
+    row.update(overrides)
+    return row
+
+
+class TestFetchWarehouse:
+    """Tests for fetch_warehouse normalization."""
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_fetches_generation_and_resource_constraint(self, mock_show_resources):
+        mock_show_resources.return_value = [
+            _warehouse_show_row(
+                generation="2",
+                resource_constraint="STANDARD_GEN_2",
+                enable_query_acceleration="false",
+                query_acceleration_max_scale_factor="8",
+            )
+        ]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=False)
+
+        assert result["generation"] == "2"
+        assert result["resource_constraint"] == "STANDARD_GEN_2"
+        assert result["enable_query_acceleration"] is False
+        assert result["query_acceleration_max_scale_factor"] == "8"
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_derives_standard_constraint_from_generation(self, mock_show_resources):
+        mock_show_resources.return_value = [_warehouse_show_row(generation="2")]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=False)
+
+        assert result["generation"] == "2"
+        assert result["resource_constraint"] == "STANDARD_GEN_2"
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_derives_generation_from_standard_constraint(self, mock_show_resources):
+        mock_show_resources.return_value = [_warehouse_show_row(resource_constraint="STANDARD_GEN_1")]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=False)
+
+        assert result["generation"] == "1"
+        assert result["resource_constraint"] == "STANDARD_GEN_1"
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_treats_null_and_missing_generation_fields_as_none(self, mock_show_resources):
+        mock_show_resources.return_value = [
+            _warehouse_show_row(
+                generation="null",
+                resource_constraint="",
+                enable_query_acceleration="null",
+                query_acceleration_max_scale_factor="null",
+            )
+        ]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=False)
+
+        assert result["generation"] is None
+        assert result["resource_constraint"] is None
+        assert result["enable_query_acceleration"] is None
+        assert result["query_acceleration_max_scale_factor"] is None
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_preserves_snowpark_memory_constraint(self, mock_show_resources):
+        mock_show_resources.return_value = [
+            _warehouse_show_row(
+                type="SNOWPARK-OPTIMIZED",
+                size="X-SMALL",
+                resource_constraint="MEMORY_16X_x86",
+            )
+        ]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=False)
+
+        assert result["warehouse_type"] == "SNOWPARK-OPTIMIZED"
+        assert result["generation"] is None
+        assert result["resource_constraint"] == "MEMORY_16X_X86"
 
 
 class TestListResource:

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -7,6 +7,7 @@ All tests use mocked URN, FQN, and Props objects - no Snowflake connection requi
 
 import pytest
 
+from snowcap import resources as res
 from snowcap.lifecycle import (
     fqn_to_sql,
     create_resource,
@@ -734,6 +735,16 @@ class TestUpdateDefault:
         props = MockProps("")
         with pytest.raises(NotImplementedError, match="'name'"):
             update__default(urn, data, props)
+
+    def test_multiple_warehouse_properties_combined_in_one_statement(self):
+        """Gen2 warehouse fields work with combined ALTER ... SET updates."""
+        urn = make_urn(ResourceType.WAREHOUSE, "MY_WH")
+        data = {
+            "resource_constraint": "STANDARD_GEN_2",
+            "generation": "2",
+        }
+        result = update__default(urn, data, res.Warehouse.props)
+        assert result == "ALTER WAREHOUSE MY_WH SET GENERATION = '2' RESOURCE_CONSTRAINT = STANDARD_GEN_2"
 
 
 # ============================================================================

--- a/tests/test_resource_types.py
+++ b/tests/test_resource_types.py
@@ -217,6 +217,8 @@ class TestWarehouse:
             owner="SYSADMIN",
             warehouse_type="STANDARD",
             warehouse_size="MEDIUM",
+            generation="2",
+            resource_constraint="STANDARD_GEN_2",
             max_cluster_count=5,
             min_cluster_count=1,
             scaling_policy="ECONOMY",
@@ -231,6 +233,8 @@ class TestWarehouse:
             statement_timeout_in_seconds=3600,
         )
         assert wh._data.warehouse_size == WarehouseSize.MEDIUM
+        assert wh._data.generation == res.WarehouseGeneration.GEN2
+        assert wh._data.resource_constraint == res.WarehouseResourceConstraint.STANDARD_GEN_2
         assert wh._data.max_cluster_count == 5
         assert wh._data.auto_suspend == 300
         assert wh._data.initially_suspended is True
@@ -248,11 +252,63 @@ class TestWarehouse:
         assert wh._data.auto_suspend == 600
         assert wh._data.auto_resume is True
         assert wh._data.max_cluster_count == 1
+        assert wh._data.generation is None
+        assert wh._data.resource_constraint is None
+        assert wh._data.enable_query_acceleration is None
+        assert wh._data.query_acceleration_max_scale_factor is None
 
     def test_warehouse_size_enum_conversion(self):
         """Test Warehouse size enum conversion from string."""
         wh = res.Warehouse(name="test_wh", warehouse_size="LARGE")
         assert wh._data.warehouse_size == WarehouseSize.LARGE
+
+    def test_warehouse_generation_enum_conversion(self):
+        """Test Warehouse generation enum conversion from string."""
+        wh = res.Warehouse(name="test_wh", generation="2")
+        assert wh._data.generation == res.WarehouseGeneration.GEN2
+
+        wh = res.Warehouse(name="test_wh", generation="GEN1")
+        assert wh._data.generation == res.WarehouseGeneration.GEN1
+
+    def test_warehouse_resource_constraint_enum_conversion(self):
+        """Test Warehouse resource constraint enum conversion from string."""
+        wh = res.Warehouse(name="test_wh", resource_constraint="STANDARD_GEN_2")
+        assert wh._data.resource_constraint == res.WarehouseResourceConstraint.STANDARD_GEN_2
+
+        wh = res.Warehouse(
+            name="test_wh",
+            warehouse_type="SNOWPARK-OPTIMIZED",
+            resource_constraint="MEMORY_16X_X86",
+        )
+        assert wh._data.resource_constraint == res.WarehouseResourceConstraint.MEMORY_16X_X86
+
+    def test_warehouse_generation_requires_standard_type(self):
+        """Test generation is only valid for standard warehouses."""
+        with pytest.raises(ValueError, match="generation is only valid"):
+            res.Warehouse(name="test_wh", warehouse_type="SNOWPARK-OPTIMIZED", generation="2")
+
+    def test_warehouse_generation_and_resource_constraint_must_agree(self):
+        """Test generation and standard resource constraint compatibility."""
+        with pytest.raises(ValueError, match="must describe the same"):
+            res.Warehouse(name="test_wh", generation="2", resource_constraint="STANDARD_GEN_1")
+
+    def test_warehouse_gen2_rejects_x5large_and_x6large(self):
+        """Test unsupported Gen2 standard warehouse sizes."""
+        with pytest.raises(ValueError, match="do not support X5LARGE or X6LARGE"):
+            res.Warehouse(name="test_wh", warehouse_size="X5LARGE", generation="2")
+        with pytest.raises(ValueError, match="do not support X5LARGE or X6LARGE"):
+            res.Warehouse(name="test_wh", warehouse_size="X6LARGE", resource_constraint="STANDARD_GEN_2")
+
+    def test_warehouse_resource_constraint_must_match_warehouse_type(self):
+        """Test standard and Snowpark resource constraint families."""
+        with pytest.raises(ValueError, match="STANDARD warehouses only support"):
+            res.Warehouse(name="test_wh", resource_constraint="MEMORY_16X")
+        with pytest.raises(ValueError, match="SNOWPARK-OPTIMIZED warehouses only support"):
+            res.Warehouse(
+                name="test_wh",
+                warehouse_type="SNOWPARK-OPTIMIZED",
+                resource_constraint="STANDARD_GEN_2",
+            )
 
 
 class TestUser:

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -33,6 +33,37 @@ def test_enum_field_serialization():
     assert warehouse._data.warehouse_size == WarehouseSize.XSMALL
 
 
+def test_warehouse_generation_create_sql():
+    warehouse = res.Warehouse(name="WH", generation="2")
+    sql = warehouse.create_sql()
+    assert "GENERATION = '2'" in sql
+    assert "ENABLE_QUERY_ACCELERATION" not in sql
+    assert "QUERY_ACCELERATION_MAX_SCALE_FACTOR" not in sql
+
+
+def test_warehouse_resource_constraint_create_sql():
+    warehouse = res.Warehouse(name="WH", resource_constraint="STANDARD_GEN_2")
+    assert "RESOURCE_CONSTRAINT = STANDARD_GEN_2" in warehouse.create_sql()
+
+
+def test_warehouse_consistent_generation_and_resource_constraint_create_sql():
+    warehouse = res.Warehouse(name="WH", generation="2", resource_constraint="STANDARD_GEN_2")
+    sql = warehouse.create_sql()
+    assert "GENERATION = '2'" in sql
+    assert "RESOURCE_CONSTRAINT = STANDARD_GEN_2" in sql
+
+
+def test_warehouse_explicit_query_acceleration_create_sql():
+    warehouse = res.Warehouse(
+        name="WH",
+        enable_query_acceleration=False,
+        query_acceleration_max_scale_factor=8,
+    )
+    sql = warehouse.create_sql()
+    assert "ENABLE_QUERY_ACCELERATION = FALSE" in sql
+    assert "QUERY_ACCELERATION_MAX_SCALE_FACTOR = 8" in sql
+
+
 @pytest.fixture(
     params=SQL_FIXTURES,
     ids=[f"{resource_cls.__name__}({idx})" for resource_cls, _, idx in SQL_FIXTURES],
@@ -334,5 +365,4 @@ class TestTagMaskingPolicyReferenceNormalization:
         )
         assert ref_mixed._data.tag_name == ref_lower._data.tag_name
         assert ref_mixed._data.masking_policy_name == ref_lower._data.masking_policy_name
-
 


### PR DESCRIPTION
Summary:
- Add Warehouse generation and resource_constraint support with validation and SQL rendering.
- Normalize Gen2 fields from SHOW WAREHOUSES and inherit QAS defaults unless explicitly configured.
- Fix multi-property update SQL so each changed property emits a deterministic ALTER statement.
- Update warehouse docs, fixtures, and focused tests.

Tests:
- /tmp/snowcap-test-venv/bin/python -m pytest -n 0 tests/test_resource_types.py tests/test_resources.py tests/test_data_provider.py tests/test_blueprint.py tests/test_lifecycle.py
- /tmp/snowcap-test-venv/bin/python -m ruff check snowcap/resources/warehouse.py snowcap/data_provider.py snowcap/lifecycle.py snowcap/blueprint.py