### PR TITLE
fix(grants): order READ before WRITE on bulk stage grants

### DIFF
--- a/snowcap/blueprint.py
+++ b/snowcap/blueprint.py
@@ -1525,14 +1525,20 @@ class Blueprint:
                 resource.requires(resource.container.container)
 
     def _create_stage_privilege_refs(self) -> None:
-        stage_grants: dict[str, list[Grant]] = {}
+        stage_grants: dict[tuple, list[Grant]] = {}
 
         for resource in _walk(self._root):
             if isinstance(resource, Grant):
-                if resource._data.on_type == ResourceType.STAGE:
-                    if resource._data.on not in stage_grants:
-                        stage_grants[resource._data.on] = []
-                    stage_grants[resource._data.on].append(resource)
+                # Snowflake requires READ before/with WRITE on a stage. Catch
+                # both direct grants (on_type == STAGE) and bulk ALL/FUTURE
+                # grants (items_type == STAGE), keyed by exact scope so the
+                # WRITE -> READ dependency below covers each case.
+                d = resource._data
+                if d.on_type == ResourceType.STAGE or d.items_type == ResourceType.STAGE:
+                    key = (d.on_type, d.on, d.grant_type, d.items_type)
+                    if key not in stage_grants:
+                        stage_grants[key] = []
+                    stage_grants[key].append(resource)
 
         def _apply_refs(stage_grants):
             for stage in stage_grants.keys():

--- a/tests/integration/test_blueprint.py
+++ b/tests/integration/test_blueprint.py
@@ -637,6 +637,42 @@ def test_stage_read_write_privilege_execution_order(cursor, suffix, marked_for_c
     blueprint.apply(session, plan)
 
 
+def test_bulk_stage_read_write_privilege_execution_order(cursor, suffix, test_db, marked_for_cleanup):
+    """
+    Snowflake rejects WRITE on a stage unless READ is granted first/together.
+    This also covers bulk ALL/FUTURE stage grants: without the WRITE -> READ
+    dependency, same-level grants for a role run concurrently and WRITE can
+    reach Snowflake before READ, failing with a privilege order violation.
+
+    Apply READ/WRITE across all four ALL/FUTURE x DATABASE/SCHEMA scopes and
+    assert the apply succeeds (it raises pre-fix).
+    """
+    session = cursor.connection
+
+    role_name = f"BULK_STAGE_ACCESS_ROLE_{suffix}"
+    role = res.Role(name=role_name)
+
+    scopes = [
+        f"all stages in database {test_db}",
+        f"all stages in schema {test_db}.PUBLIC",
+        f"future stages in database {test_db}",
+        f"future stages in schema {test_db}.PUBLIC",
+    ]
+
+    grants = []
+    for scope in scopes:
+        grants.append(res.Grant(priv="READ", on=scope, to=role))
+        grants.append(res.Grant(priv="WRITE", on=scope, to=role))
+
+    blueprint = Blueprint(resources=[role, *grants])
+
+    marked_for_cleanup.append(role)
+
+    plan = blueprint.plan(session)
+    assert len(plan) == 1 + len(grants)
+    blueprint.apply(session, plan)
+
+
 def test_grant_database_role_to_database_role(cursor, suffix, marked_for_cleanup):
     session = cursor.connection
     bp = Blueprint()

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -442,6 +442,56 @@ def test_blueprint_reference_sorting(session_ctx, remote_state):
     assert db3_change.resource_cls == res.Database
 
 
+def test_blueprint_bulk_stage_read_write_ordering(session_ctx):
+    """
+    Bulk (ALL/FUTURE) stage grants must order READ before WRITE, just like
+    grants on a single named stage. _create_stage_privilege_refs should make
+    each WRITE grant depend on the matching READ grant over the same scope,
+    for every ALL/FUTURE x DATABASE/SCHEMA combination.
+    """
+    role = res.Role(name="R_RW")
+
+    # Every ALL/FUTURE x DATABASE/SCHEMA combination must order READ before
+    # WRITE, since _create_stage_privilege_refs keys on items_type == STAGE
+    # regardless of container type or grant type.
+    all_db_read = res.Grant(priv="READ", on="all stages in database DB", to=role)
+    all_db_write = res.Grant(priv="WRITE", on="all stages in database DB", to=role)
+    all_sc_read = res.Grant(priv="READ", on="all stages in schema DB.SC", to=role)
+    all_sc_write = res.Grant(priv="WRITE", on="all stages in schema DB.SC", to=role)
+    future_db_read = res.Grant(priv="READ", on="future stages in database DB", to=role)
+    future_db_write = res.Grant(priv="WRITE", on="future stages in database DB", to=role)
+    future_sc_read = res.Grant(priv="READ", on="future stages in schema DB.SC", to=role)
+    future_sc_write = res.Grant(priv="WRITE", on="future stages in schema DB.SC", to=role)
+
+    blueprint = Blueprint(
+        resources=[
+            role,
+            all_db_read,
+            all_db_write,
+            all_sc_read,
+            all_sc_write,
+            future_db_read,
+            future_db_write,
+            future_sc_read,
+            future_sc_write,
+        ]
+    )
+    blueprint._finalize(session_ctx)
+
+    # WRITE depends on READ -> READ is applied first, for each scope
+    assert all_db_read in all_db_write.refs
+    assert all_sc_read in all_sc_write.refs
+    assert future_db_read in future_db_write.refs
+    assert future_sc_read in future_sc_write.refs
+
+    # Scopes must not cross-link: a WRITE only depends on the READ over its
+    # exact same scope, not on READs from other container/grant-type scopes.
+    assert all_sc_read not in all_db_write.refs
+    assert future_db_read not in all_db_write.refs
+    assert future_sc_read not in future_db_write.refs
+    assert all_db_read not in future_sc_write.refs
+
+
 def test_blueprint_ownership_sorting(session_ctx, remote_state):
 
     role = res.Role(name="SOME_ROLE")


### PR DESCRIPTION
## Summary

Snowflake refuses to grant `WRITE` on a stage to a role that does not already
hold `READ` on it. The privileges have to be granted in order, or together. This
rule also covers `ALL`/`FUTURE` grants:

```
GRANT WRITE ON FUTURE STAGES IN DATABASE db TO ROLE r;
-- SQL compilation error: Privilege order violation for the future grants on
-- stage. READ should be granted before/simultaneously with WRITE.
```

Snowcap already accounts for this with `Blueprint._create_stage_privilege_refs`,
which makes every `WRITE` grant depend on the matching `READ` grant so the two
land at different dependency levels and apply in the right order. But it only
catches grants on a single named stage. Bulk grants over `ALL`/`FUTURE` stages
are missed, and the apply fails.

## Root cause

`_create_stage_privilege_refs` collects grants by checking `on_type == STAGE`:

```python
if resource._data.on_type == ResourceType.STAGE:
    stage_grants.setdefault(resource._data.on, []).append(resource)
```

That only holds for a grant on a specific stage (`GRANT WRITE ON STAGE db.sc.s`).
For a bulk grant the parser puts the container in `on_type` and the stage in
`items_type`:

| grant | `on_type` | `items_type` |
|-------|-----------|--------------|
| `WRITE ON STAGE db.sc.s` | `STAGE` | `None` |
| `WRITE ON ALL STAGES IN DATABASE db` | `DATABASE` | `STAGE` |
| `WRITE ON FUTURE STAGES IN SCHEMA db.sc` | `SCHEMA` | `STAGE` |

So bulk stage grants never enter `stage_grants`, no `WRITE -> READ` dependency is
created, and the two grants end up at the same dependency level. At apply time
same-level grants for a role run concurrently (`execute_commands_in_parallel`),
so `WRITE` can reach Snowflake before `READ` and the statement fails.

## Fix

Also collect grants whose `items_type` is `STAGE`, and group reads and writes by
the full scope so only grants over the same set of stages get linked:

```python
d = resource._data
if d.on_type == ResourceType.STAGE or d.items_type == ResourceType.STAGE:
    key = (d.on_type, d.on, d.grant_type, d.items_type)
    stage_grants.setdefault(key, []).append(resource)
```

The existing `WRITE -> READ` pass is unchanged; it now runs over bulk grants too.
This covers all `ALL`/`FUTURE` × `DATABASE`/`SCHEMA` combinations.

## Testing

All CI gates pass: `ruff check snowcap/`, `mypy` typecheck, and the full unit
suite (`pytest --ignore=tests/integration`, 1533 passed). The existing
single-named-stage integration test
(`test_stage_read_write_privilege_execution_order`) still passes against a live
account, confirming no regression on that path.

### Unit test

Added `test_blueprint_bulk_stage_read_write_ordering` in `tests/test_blueprint.py`.
The fix is container- and grant-type-agnostic (it keys on `items_type == STAGE`),
so the test asserts the `WRITE -> READ` dependency for **all four**
`ALL`/`FUTURE` × `DATABASE`/`SCHEMA` combinations after `Blueprint._finalize`, and
asserts distinct scopes do **not** cross-link (a `WRITE` only depends on the
`READ` over its exact same scope). Verified it fails on `main` (bulk `WRITE`
carries no `READ` dependency) and passes with the fix.

### Integration test

Added `test_bulk_stage_read_write_privilege_execution_order` in
`tests/integration/test_blueprint.py` (marked `requires_snowflake`). It applies
`READ`/`WRITE` across all four `ALL`/`FUTURE` × `DATABASE`/`SCHEMA` scopes to a
role and asserts the apply succeeds. Confirmed end-to-end: on `main` the apply
raises the real Snowflake error — `003511 (23001): Privilege order violation for
the future grants on stage. READ should be granted before/simultaneously with
WRITE` — and with the fix the same apply succeeds.
