### PR TITLE
feat(security_integration): implement custom OAuth integration (OAUTH_CLIENT = CUSTOM)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -59,6 +59,7 @@
 * [Service](resources/service.md)
 * [SessionPolicy](resources/session_policy.md)
 * [Share](resources/share.md)
+* [SnowflakeCustomOAuthSecurityIntegration](resources/snowflake_custom_oauth_security_integration.md)
 * [SharedDatabase](resources/shared_database.md)
 * [SnowflakePartnerOAuthSecurityIntegration](resources/snowflake_partner_oauth_security_integration.md)
 * [SnowservicesOAuthSecurityIntegration](resources/snowservices_oauth_security_integration.md)

--- a/docs/resources/snowflake_custom_oauth_security_integration.md
+++ b/docs/resources/snowflake_custom_oauth_security_integration.md
@@ -1,0 +1,81 @@
+---
+description: >-
+  A Snowflake OAuth security integration for a custom OAuth client, with credentials generated and managed by Snowflake.
+---
+
+# SnowflakeCustomOAuthSecurityIntegration
+
+[Snowflake Documentation](https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake) | Snowcap CLI label: `snowflake_custom_oauth_security_integration`
+
+A security integration in Snowflake for a custom OAuth client that Snowflake itself
+issues and manages. Unlike the partner integrations, Snowflake generates the OAuth
+client_id and client_secret for you; retrieve them with
+SYSTEM$SHOW_OAUTH_CLIENT_SECRETS, they cannot be set through this resource.
+ACCOUNTADMIN, ORGADMIN, GLOBALORGADMIN, and SECURITYADMIN are always blocked by
+Snowflake and must not be listed in blocked_roles_list.
+Every property except oauth_client_type is applied with ALTER SECURITY INTEGRATION
+and never recreates the integration. oauth_client_type cannot be changed after
+creation: snowcap fails the plan rather than recreating the integration, because
+recreation would rotate the Snowflake-issued client_id/client_secret and break live
+OAuth clients. To change it, recreate the integration manually and migrate clients.
+oauth_alternate_redirect_uris is CREATE-ONLY in snowcap: it is not fetchable, so
+editing it in YAML after creation produces no diff and no error. Changes must be
+applied out-of-band with
+ALTER SECURITY INTEGRATION <name> SET OAUTH_ALTERNATE_REDIRECT_URIS = (...).
+
+
+## Examples
+
+### YAML
+
+```yaml
+security_integrations:
+  - name: claude_mcp_oauth
+    enabled: true
+    oauth_client_type: CONFIDENTIAL
+    oauth_redirect_uri: https://claude.ai/api/mcp/auth_callback
+    oauth_issue_refresh_tokens: true
+    oauth_refresh_token_validity: 7776000
+    oauth_use_secondary_roles: NONE
+    oauth_enforce_pkce: true
+    blocked_roles_list:
+      - SYSADMIN
+    comment: OAuth client for the Claude MCP connector
+```
+
+
+### Python
+
+```python
+claude_mcp_oauth = SnowflakeCustomOAuthSecurityIntegration(
+    name="claude_mcp_oauth",
+    enabled=True,
+    oauth_client_type="CONFIDENTIAL",
+    oauth_redirect_uri="https://claude.ai/api/mcp/auth_callback",
+    oauth_issue_refresh_tokens=True,
+    oauth_refresh_token_validity=7776000,
+    oauth_use_secondary_roles="NONE",
+    oauth_enforce_pkce=True,
+    blocked_roles_list=["SYSADMIN"],
+    comment="OAuth client for the Claude MCP connector"
+)
+```
+
+
+## Fields
+
+* `name` (string, required) - The name of the security integration.
+* `enabled` (bool) - Specifies if the security integration is enabled. Defaults to True.
+* `oauth_client_type` (string or OAuthClientType, required) - The type of OAuth client. Supported values are 'CONFIDENTIAL' and 'PUBLIC'. Cannot be changed after creation.
+* `oauth_redirect_uri` (string, required) - The redirect URI the client uses to complete the OAuth flow.
+* `oauth_alternate_redirect_uris` (list) - Additional allowed redirect URIs, set at creation only.
+* `oauth_issue_refresh_tokens` (bool) - Indicates if refresh tokens should be issued. Defaults to True.
+* `oauth_refresh_token_validity` (int) - The validity period of the refresh token in seconds. Defaults to 7776000.
+* `oauth_use_secondary_roles` (string or OAuthUseSecondaryRoles) - Whether secondary roles are activated for OAuth sessions. Supported values are 'IMPLICIT' and 'NONE'. Defaults to 'NONE'.
+* `oauth_enforce_pkce` (bool) - Requires clients to use PKCE during the OAuth flow. Defaults to False.
+* `network_policy` (string) - The network policy enforced for requests made with this integration's tokens.
+* `pre_authorized_roles_list` (list) - Roles granted access without displaying a consent screen to the user.
+* `blocked_roles_list` (list) - Roles that are not allowed to use this integration.
+* `comment` (string) - A comment about the security integration.
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,7 @@ nav:
         - ExternalAccessIntegration: resources/external_access_integration.md
       - Security:
         - APIAuthenticationSecurityIntegration: resources/api_authentication_security_integration.md
+        - SnowflakeCustomOAuthSecurityIntegration: resources/snowflake_custom_oauth_security_integration.md
         - SnowflakePartnerOAuthSecurityIntegration: resources/snowflake_partner_oauth_security_integration.md
         - SnowservicesOAuthSecurityIntegration: resources/snowservices_oauth_security_integration.md
       - Storage:

--- a/snowcap/blueprint.py
+++ b/snowcap/blueprint.py
@@ -44,6 +44,7 @@ from .error_formatting import (
 from .exceptions import (
     DuplicateResourceException,
     InvalidResourceException,
+    MarkedForReplacementException,
     MissingPrivilegeException,
     MissingResourceException,
     NonConformingPlanException,
@@ -2343,7 +2344,8 @@ def diff(remote_state: State, manifest: Manifest) -> list:
         delta = _diff_resource_data(remote_state[urn], manifest_item.data)
         owner_attr = delta.pop("owner", None)
 
-        replace_resource = False
+        replacement_attr = None
+        replacement_message = None
         create_resource = False
         ignore_fields = set()
 
@@ -2355,7 +2357,8 @@ def diff(remote_state: State, manifest: Manifest) -> list:
             change_is_known_after_apply = attr_metadata.known_after_apply
             change_should_be_ignored = attr in manifest_item.lifecycle.ignore_changes or attr_metadata.ignore_changes
             if change_requires_replacement:
-                replace_resource = True
+                replacement_attr = attr
+                replacement_message = attr_metadata.replacement_message
                 break
             elif change_triggers_create:
                 create_resource = True
@@ -2367,8 +2370,14 @@ def diff(remote_state: State, manifest: Manifest) -> list:
             elif change_should_be_ignored:
                 ignore_fields.add(attr)
 
-        if replace_resource:
-            raise NotImplementedError("replace_resource")
+        if replacement_attr:
+            message = (
+                f"Cannot update {urn}: changing '{replacement_attr}' requires replacing the resource, "
+                "which snowcap does not do."
+            )
+            if replacement_message:
+                message = f"{message} {replacement_message}"
+            raise MarkedForReplacementException(message)
 
         if create_resource:
             changes.append(

--- a/snowcap/builtins.py
+++ b/snowcap/builtins.py
@@ -26,3 +26,14 @@ SYSTEM_SECURITY_INTEGRATIONS = [
     # Present on every new Snowflake account (type OAUTH - LOCAL_APPLICATION)
     "SNOWFLAKE$LOCAL_APPLICATION",
 ]
+
+# Snowflake always blocks these roles from a CUSTOM OAuth integration, regardless of
+# what's in BLOCKED_ROLES_LIST, and echoes them back in DESC. Shared by the spec (which
+# rejects them in blocked_roles_list) and the fetch layer (which strips them from state
+# fetched from Snowflake), so both sides agree on what "always blocked" means.
+ALWAYS_BLOCKED_OAUTH_ROLES = [
+    "ACCOUNTADMIN",
+    "ORGADMIN",
+    "GLOBALORGADMIN",
+    "SECURITYADMIN",
+]

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -43,6 +43,7 @@ from .resource_name import (
     resource_name_from_snowflake_metadata,
 )
 from .resources.authentication_policy import _PAT_POLICY_DEFAULT
+from .resources.security_integration import _canonicalize_role_name
 from .resources.warehouse import ADAPTIVE_UNSUPPORTED_FIELDS
 
 __this__ = sys.modules[__name__]
@@ -2661,10 +2662,14 @@ def fetch_security_integration(session: SnowflakeConnection, fqn: FQN):
                 "owner": owner,
             }
         elif oauth_client == "CUSTOM":
+            # Canonicalize role names the same way the spec does (_canonicalize_role_name)
+            # so a quoted, case-sensitive role compares equal on both sides.
             pre_authorized_roles_list = properties.get("pre_authorized_roles_list") or None
             if pre_authorized_roles_list:
-                pre_authorized_roles_list = sorted(pre_authorized_roles_list)
-            blocked_roles_list = set(properties.get("blocked_roles_list") or []) - set(ALWAYS_BLOCKED_OAUTH_ROLES)
+                pre_authorized_roles_list = sorted(_canonicalize_role_name(role) for role in pre_authorized_roles_list)
+            blocked_roles_list = {
+                _canonicalize_role_name(role) for role in properties.get("blocked_roles_list") or []
+            } - set(ALWAYS_BLOCKED_OAUTH_ROLES)
             return {
                 "name": _quote_snowflake_identifier(data["name"]),
                 "type": type_,

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -12,6 +12,7 @@ from snowflake.connector import SnowflakeConnection
 from snowflake.connector.errors import ProgrammingError
 
 from .builtins import (
+    ALWAYS_BLOCKED_OAUTH_ROLES,
     SYSTEM_DATABASES,
     SYSTEM_ROLES,
     SYSTEM_SECURITY_INTEGRATIONS,
@@ -2659,19 +2660,29 @@ def fetch_security_integration(session: SnowflakeConnection, fqn: FQN):
                 "enabled": data["enabled"] == "true",
                 "owner": owner,
             }
+        elif oauth_client == "CUSTOM":
+            pre_authorized_roles_list = properties.get("pre_authorized_roles_list") or None
+            if pre_authorized_roles_list:
+                pre_authorized_roles_list = sorted(pre_authorized_roles_list)
+            blocked_roles_list = set(properties.get("blocked_roles_list") or []) - set(ALWAYS_BLOCKED_OAUTH_ROLES)
+            return {
+                "name": _quote_snowflake_identifier(data["name"]),
+                "type": type_,
+                "oauth_client": oauth_client,
+                "enabled": data["enabled"] == "true",
+                "oauth_client_type": properties.get("oauth_client_type"),
+                "oauth_redirect_uri": properties.get("oauth_redirect_uri"),
+                "oauth_issue_refresh_tokens": properties.get("oauth_issue_refresh_tokens"),
+                "oauth_refresh_token_validity": int(properties["oauth_refresh_token_validity"]),
+                "oauth_use_secondary_roles": properties.get("oauth_use_secondary_roles"),
+                "oauth_enforce_pkce": properties.get("oauth_enforce_pkce"),
+                "network_policy": properties.get("network_policy"),
+                "pre_authorized_roles_list": pre_authorized_roles_list,
+                "blocked_roles_list": sorted(blocked_roles_list) or None,
+                "comment": data["comment"] or None,
+                "owner": owner,
+            }
     raise Exception(f"Unsupported security integration type {data['type']}")
-
-    # return {
-    #     "name": _quote_snowflake_identifier(data["name"]),
-    #     "type": type_,
-    #     "enabled": data["enabled"] == "true",
-    #     "oauth_client": oauth_client,
-    #     # "oauth_client_secret": None,
-    #     # "oauth_redirect_uri": None,
-    #     "oauth_issue_refresh_tokens": properties["oauth_issue_refresh_tokens"] == "true",
-    #     "oauth_refresh_token_validity": properties["oauth_refresh_token_validity"],
-    #     "comment": data["comment"] or None,
-    # }
 
 
 def fetch_sequence(session: SnowflakeConnection, fqn: FQN):

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -2670,6 +2670,9 @@ def fetch_security_integration(session: SnowflakeConnection, fqn: FQN):
             blocked_roles_list = {
                 _canonicalize_role_name(role) for role in properties.get("blocked_roles_list") or []
             } - set(ALWAYS_BLOCKED_OAUTH_ROLES)
+            oauth_refresh_token_validity = properties.get("oauth_refresh_token_validity")
+            if oauth_refresh_token_validity is not None:
+                oauth_refresh_token_validity = int(oauth_refresh_token_validity)
             return {
                 "name": _quote_snowflake_identifier(data["name"]),
                 "type": type_,
@@ -2678,7 +2681,7 @@ def fetch_security_integration(session: SnowflakeConnection, fqn: FQN):
                 "oauth_client_type": properties.get("oauth_client_type"),
                 "oauth_redirect_uri": properties.get("oauth_redirect_uri"),
                 "oauth_issue_refresh_tokens": properties.get("oauth_issue_refresh_tokens"),
-                "oauth_refresh_token_validity": int(properties["oauth_refresh_token_validity"]),
+                "oauth_refresh_token_validity": oauth_refresh_token_validity,
                 "oauth_use_secondary_roles": properties.get("oauth_use_secondary_roles"),
                 "oauth_enforce_pkce": properties.get("oauth_enforce_pkce"),
                 "network_policy": properties.get("network_policy"),

--- a/snowcap/resources/__init__.py
+++ b/snowcap/resources/__init__.py
@@ -53,6 +53,7 @@ from .schema import Schema
 from .secret import GenericSecret, OAuthSecret, PasswordSecret
 from .security_integration import (
     APIAuthenticationSecurityIntegration,
+    SnowflakeCustomOAuthSecurityIntegration,
     SnowflakePartnerOAuthSecurityIntegration,
     SnowservicesOAuthSecurityIntegration,
 )
@@ -142,6 +143,7 @@ __all__ = [
     "Sequence",
     "Service",
     "Share",
+    "SnowflakeCustomOAuthSecurityIntegration",
     "SharedDatabase",
     "SnowflakeIcebergTable",
     "SnowflakePartnerOAuthSecurityIntegration",

--- a/snowcap/resources/resource.py
+++ b/snowcap/resources/resource.py
@@ -213,6 +213,9 @@ class ResourceSpecMetadata:
     triggers_create: bool = False
     ignore_changes: bool = False
     known_after_apply: bool = False
+    # Extra context appended to the plan-time error when a triggers_replacement
+    # field changes (e.g. what recreation would break for this resource).
+    replacement_message: Optional[str] = None
     edition: set[AccountEdition] = field(
         default_factory=lambda: {AccountEdition.STANDARD, AccountEdition.ENTERPRISE, AccountEdition.BUSINESS_CRITICAL}
     )

--- a/snowcap/resources/security_integration.py
+++ b/snowcap/resources/security_integration.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 
+from ..builtins import ALWAYS_BLOCKED_OAUTH_ROLES
 from ..enums import ParseableEnum, ResourceType
 from ..props import (
     BoolProp,
@@ -13,6 +14,14 @@ from ..resource_name import ResourceName
 from ..scope import AccountScope
 from .resource import NamedResource, Resource, ResourceSpec
 from .role import Role
+
+
+def _canonicalize_role_name(name: str) -> str:
+    """Snowflake echoes role names back in DESC uppercased, unless the role was
+    created with a quoted, case-sensitive identifier. Normalize the same way so a
+    manifest role name compares equal to what fetch returns."""
+    resource_name = ResourceName(name)
+    return resource_name._name if resource_name._quoted else resource_name._name.upper()
 
 
 class SecurityIntegrationType(ParseableEnum):
@@ -29,6 +38,16 @@ class OAuthClient(ParseableEnum):
     SNOWSERVICES_INGRESS = "SNOWSERVICES_INGRESS"
     TABLEAU_DESKTOP = "TABLEAU_DESKTOP"
     TABLEAU_SERVER = "TABLEAU_SERVER"
+
+
+class OAuthClientType(ParseableEnum):
+    CONFIDENTIAL = "CONFIDENTIAL"
+    PUBLIC = "PUBLIC"
+
+
+class OAuthUseSecondaryRoles(ParseableEnum):
+    IMPLICIT = "IMPLICIT"
+    NONE = "NONE"
 
 
 @dataclass(unsafe_hash=True)
@@ -339,6 +358,181 @@ class APIAuthenticationSecurityIntegration(NamedResource, Resource):
         )
 
 
+@dataclass(unsafe_hash=True)
+class _SnowflakeCustomOAuthSecurityIntegration(ResourceSpec):
+    name: ResourceName
+    type: SecurityIntegrationType = SecurityIntegrationType.OAUTH
+    enabled: bool = True
+    oauth_client: OAuthClient = OAuthClient.CUSTOM
+    oauth_client_type: OAuthClientType = field(default=None, metadata={"triggers_replacement": True})
+    oauth_redirect_uri: str = None
+    oauth_alternate_redirect_uris: list[str] = field(default=None, metadata={"fetchable": False})
+    oauth_issue_refresh_tokens: bool = True
+    oauth_refresh_token_validity: int = 7776000
+    oauth_use_secondary_roles: OAuthUseSecondaryRoles = OAuthUseSecondaryRoles.NONE
+    oauth_enforce_pkce: bool = False
+    network_policy: str = None
+    pre_authorized_roles_list: list[str] = None
+    blocked_roles_list: list[str] = None
+    comment: str = None
+    owner: Role = "ACCOUNTADMIN"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.oauth_client_type is None:
+            raise ValueError("oauth_client_type must be set")
+        if self.oauth_redirect_uri is None:
+            raise ValueError("oauth_redirect_uri must be set")
+        if self.pre_authorized_roles_list is not None:
+            self.pre_authorized_roles_list = sorted(
+                _canonicalize_role_name(role) for role in self.pre_authorized_roles_list
+            )
+        if self.blocked_roles_list is not None:
+            self.blocked_roles_list = sorted(_canonicalize_role_name(role) for role in self.blocked_roles_list)
+            always_blocked = set(self.blocked_roles_list) & set(ALWAYS_BLOCKED_OAUTH_ROLES)
+            if always_blocked:
+                raise ValueError(
+                    f"blocked_roles_list must not include roles Snowflake always blocks: {sorted(always_blocked)}"
+                )
+
+
+class SnowflakeCustomOAuthSecurityIntegration(NamedResource, Resource):
+    """
+    Description:
+        A security integration in Snowflake for a custom OAuth client that Snowflake itself
+        issues and manages. Unlike the partner integrations, Snowflake generates the OAuth
+        client_id and client_secret for you; retrieve them with
+        SYSTEM$SHOW_OAUTH_CLIENT_SECRETS, they cannot be set through this resource.
+
+        ACCOUNTADMIN, ORGADMIN, GLOBALORGADMIN, and SECURITYADMIN are always blocked by
+        Snowflake and must not be listed in blocked_roles_list.
+
+        Every property except oauth_client_type is applied with ALTER SECURITY INTEGRATION
+        and never recreates the integration. oauth_client_type cannot be changed after
+        creation: snowcap fails the plan rather than recreating the integration, because
+        recreation would rotate the Snowflake-issued client_id/client_secret and break live
+        OAuth clients. To change it, recreate the integration manually and migrate clients.
+
+        oauth_alternate_redirect_uris is CREATE-ONLY in snowcap: it is not fetchable, so
+        editing it in YAML after creation produces no diff and no error. Changes must be
+        applied out-of-band with
+        ALTER SECURITY INTEGRATION <name> SET OAUTH_ALTERNATE_REDIRECT_URIS = (...).
+
+    Snowflake Docs:
+        https://docs.snowflake.com/en/sql-reference/sql/create-security-integration-oauth-snowflake
+
+    Fields:
+        name (string, required): The name of the security integration.
+        enabled (bool): Specifies if the security integration is enabled. Defaults to True.
+        oauth_client_type (string or OAuthClientType, required): The type of OAuth client. Supported values are 'CONFIDENTIAL' and 'PUBLIC'. Cannot be changed after creation.
+        oauth_redirect_uri (string, required): The redirect URI the client uses to complete the OAuth flow.
+        oauth_alternate_redirect_uris (list): Additional allowed redirect URIs, set at creation only.
+        oauth_issue_refresh_tokens (bool): Indicates if refresh tokens should be issued. Defaults to True.
+        oauth_refresh_token_validity (int): The validity period of the refresh token in seconds. Defaults to 7776000.
+        oauth_use_secondary_roles (string or OAuthUseSecondaryRoles): Whether secondary roles are activated for OAuth sessions. Supported values are 'IMPLICIT' and 'NONE'. Defaults to 'NONE'.
+        oauth_enforce_pkce (bool): Requires clients to use PKCE during the OAuth flow. Defaults to False.
+        network_policy (string): The network policy enforced for requests made with this integration's tokens.
+        pre_authorized_roles_list (list): Roles granted access without displaying a consent screen to the user.
+        blocked_roles_list (list): Roles that are not allowed to use this integration.
+        comment (string): A comment about the security integration.
+
+    Python:
+
+        ```python
+        claude_mcp_oauth = SnowflakeCustomOAuthSecurityIntegration(
+            name="claude_mcp_oauth",
+            enabled=True,
+            oauth_client_type="CONFIDENTIAL",
+            oauth_redirect_uri="https://claude.ai/api/mcp/auth_callback",
+            oauth_issue_refresh_tokens=True,
+            oauth_refresh_token_validity=7776000,
+            oauth_use_secondary_roles="NONE",
+            oauth_enforce_pkce=True,
+            blocked_roles_list=["SYSADMIN"],
+            comment="OAuth client for the Claude MCP connector"
+        )
+        ```
+
+    Yaml:
+
+        ```yaml
+        security_integrations:
+          - name: claude_mcp_oauth
+            enabled: true
+            oauth_client_type: CONFIDENTIAL
+            oauth_redirect_uri: https://claude.ai/api/mcp/auth_callback
+            oauth_issue_refresh_tokens: true
+            oauth_refresh_token_validity: 7776000
+            oauth_use_secondary_roles: NONE
+            oauth_enforce_pkce: true
+            blocked_roles_list:
+              - SYSADMIN
+            comment: OAuth client for the Claude MCP connector
+        ```
+    """
+
+    resource_type = ResourceType.SECURITY_INTEGRATION
+    props = Props(
+        type=EnumProp("type", [SecurityIntegrationType.OAUTH]),
+        enabled=BoolProp("enabled"),
+        oauth_client=EnumProp("oauth_client", [OAuthClient.CUSTOM]),
+        oauth_client_type=EnumProp(
+            "oauth_client_type", [OAuthClientType.CONFIDENTIAL, OAuthClientType.PUBLIC], quoted=True
+        ),
+        oauth_redirect_uri=StringProp("oauth_redirect_uri"),
+        oauth_alternate_redirect_uris=StringListProp("oauth_alternate_redirect_uris", parens=True),
+        oauth_issue_refresh_tokens=BoolProp("oauth_issue_refresh_tokens"),
+        oauth_refresh_token_validity=IntProp("oauth_refresh_token_validity"),
+        oauth_use_secondary_roles=EnumProp(
+            "oauth_use_secondary_roles", [OAuthUseSecondaryRoles.IMPLICIT, OAuthUseSecondaryRoles.NONE]
+        ),
+        oauth_enforce_pkce=BoolProp("oauth_enforce_pkce"),
+        network_policy=StringProp("network_policy"),
+        pre_authorized_roles_list=StringListProp("pre_authorized_roles_list", parens=True),
+        blocked_roles_list=StringListProp("blocked_roles_list", parens=True),
+        comment=StringProp("comment"),
+    )
+    scope = AccountScope()
+    spec = _SnowflakeCustomOAuthSecurityIntegration
+
+    def __init__(
+        self,
+        name: str,
+        enabled: bool = True,
+        oauth_client_type: OAuthClientType = None,
+        oauth_redirect_uri: str = None,
+        oauth_alternate_redirect_uris: list[str] = None,
+        oauth_issue_refresh_tokens: bool = True,
+        oauth_refresh_token_validity: int = 7776000,
+        oauth_use_secondary_roles: OAuthUseSecondaryRoles = OAuthUseSecondaryRoles.NONE,
+        oauth_enforce_pkce: bool = False,
+        network_policy: str = None,
+        pre_authorized_roles_list: list[str] = None,
+        blocked_roles_list: list[str] = None,
+        comment: str = None,
+        **kwargs,
+    ):
+        kwargs.pop("type", None)
+        kwargs.pop("owner", None)
+        kwargs.pop("oauth_client", None)
+        super().__init__(name, **kwargs)
+        self._data: _SnowflakeCustomOAuthSecurityIntegration = _SnowflakeCustomOAuthSecurityIntegration(
+            name=self._name,
+            enabled=enabled,
+            oauth_client_type=oauth_client_type,
+            oauth_redirect_uri=oauth_redirect_uri,
+            oauth_alternate_redirect_uris=oauth_alternate_redirect_uris,
+            oauth_issue_refresh_tokens=oauth_issue_refresh_tokens,
+            oauth_refresh_token_validity=oauth_refresh_token_validity,
+            oauth_use_secondary_roles=oauth_use_secondary_roles,
+            oauth_enforce_pkce=oauth_enforce_pkce,
+            network_policy=network_policy,
+            pre_authorized_roles_list=pre_authorized_roles_list,
+            blocked_roles_list=blocked_roles_list,
+            comment=comment,
+        )
+
+
 def _resolver(data: dict):
     security_integration_type = SecurityIntegrationType(data["type"])
     if security_integration_type == SecurityIntegrationType.API_AUTHENTICATION:
@@ -352,9 +546,7 @@ def _resolver(data: dict):
         ]:
             return SnowflakePartnerOAuthSecurityIntegration
         elif oauth_client == OAuthClient.CUSTOM:
-            # return SnowflakeCustomOAuthSecurityIntegration
-            # return None
-            raise NotImplementedError
+            return SnowflakeCustomOAuthSecurityIntegration
         elif oauth_client == OAuthClient.SNOWSERVICES_INGRESS:
             return SnowservicesOAuthSecurityIntegration
     return None

--- a/snowcap/resources/security_integration.py
+++ b/snowcap/resources/security_integration.py
@@ -364,7 +364,18 @@ class _SnowflakeCustomOAuthSecurityIntegration(ResourceSpec):
     type: SecurityIntegrationType = SecurityIntegrationType.OAUTH
     enabled: bool = True
     oauth_client: OAuthClient = OAuthClient.CUSTOM
-    oauth_client_type: OAuthClientType = field(default=None, metadata={"triggers_replacement": True})
+    oauth_client_type: OAuthClientType = field(
+        default=None,
+        metadata={
+            "triggers_replacement": True,
+            "replacement_message": (
+                "Changing oauth_client_type requires recreating the security integration, "
+                "which rotates the Snowflake-issued client_id and client_secret and breaks "
+                "live OAuth clients. To change it, recreate the integration manually and "
+                "migrate clients to the new credentials."
+            ),
+        },
+    )
     oauth_redirect_uri: str = None
     oauth_alternate_redirect_uris: list[str] = field(default=None, metadata={"fetchable": False})
     oauth_issue_refresh_tokens: bool = True

--- a/tests/fixtures/json/snowflake_custom_oauth_security_integration.json
+++ b/tests/fixtures/json/snowflake_custom_oauth_security_integration.json
@@ -1,0 +1,18 @@
+{
+    "name": "TEST_CUSTOM_OAUTH_INTEGRATION",
+    "type": "OAUTH",
+    "enabled": true,
+    "oauth_client": "CUSTOM",
+    "oauth_client_type": "CONFIDENTIAL",
+    "oauth_redirect_uri": "https://example.com/oauth/callback",
+    "oauth_alternate_redirect_uris": ["https://example.com/oauth/callback2"],
+    "oauth_issue_refresh_tokens": true,
+    "oauth_refresh_token_validity": 7776000,
+    "oauth_use_secondary_roles": "NONE",
+    "oauth_enforce_pkce": true,
+    "network_policy": null,
+    "pre_authorized_roles_list": null,
+    "blocked_roles_list": null,
+    "owner": "ACCOUNTADMIN",
+    "comment": "Test custom OAuth security integration"
+}

--- a/tests/integration/data_provider/test_fetch_resource.py
+++ b/tests/integration/data_provider/test_fetch_resource.py
@@ -412,6 +412,29 @@ def test_fetch_api_authentication_security_integration(cursor, suffix, marked_fo
     assert result == data
 
 
+def test_fetch_snowflake_custom_oauth_security_integration(cursor, suffix, marked_for_cleanup):
+    security_integration = res.SnowflakeCustomOAuthSecurityIntegration(
+        name=f"CUSTOM_OAUTH_SECURITY_INTEGRATION_{suffix}",
+        oauth_client_type="CONFIDENTIAL",
+        oauth_redirect_uri="https://example.com/oauth/callback",
+        oauth_enforce_pkce=True,
+        oauth_issue_refresh_tokens=True,
+        oauth_refresh_token_validity=86400,
+        oauth_use_secondary_roles="IMPLICIT",
+        pre_authorized_roles_list=["PUBLIC"],
+        comment="Test custom OAuth security integration",
+        enabled=True,
+    )
+    create(cursor, security_integration)
+    marked_for_cleanup.append(security_integration)
+
+    result = safe_fetch(cursor, security_integration.urn)
+    assert result is not None
+    result = clean_resource_data(res.SnowflakeCustomOAuthSecurityIntegration.spec, result)
+    data = clean_resource_data(res.SnowflakeCustomOAuthSecurityIntegration.spec, security_integration.to_dict())
+    assert result == data
+
+
 def test_fetch_table_stream(cursor, suffix, marked_for_cleanup):
     stream = res.TableStream(
         name=f"SOME_TABLE_STREAM_{suffix}",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -60,6 +60,7 @@ from snowcap.enums import AccountEdition, BlueprintScope, ResourceType
 from snowcap.exceptions import (
     DuplicateResourceException,
     InvalidResourceException,
+    MarkedForReplacementException,
     MissingVarException,
     NonConformingPlanException,
     OrphanResourceException,
@@ -1440,8 +1441,8 @@ def test_blueprint_database_create_custom_owner_transfers_public_schema(session_
 
 
 def test_blueprint_shared_database_from_share_change_raises_not_implemented(session_ctx, remote_state):
-    # Documents today's limitation: from_share triggers_replacement, and replace_resource
-    # is unimplemented, so a from_share drift is a plan-time error rather than a silent
+    # Documents today's limitation: from_share triggers_replacement, and snowcap never
+    # replaces resources, so a from_share drift is a plan-time error rather than a silent
     # (and nonsensical) ALTER at apply time.
     remote_state[parse_URN("urn::ABCD123:database/GONG")] = {
         "name": "GONG",
@@ -1452,7 +1453,7 @@ def test_blueprint_shared_database_from_share_change_raises_not_implemented(sess
     blueprint = Blueprint(name="blueprint", resources=[shared_db])
     manifest = blueprint.generate_manifest(session_ctx)
 
-    with pytest.raises(NotImplementedError, match="replace_resource"):
+    with pytest.raises(MarkedForReplacementException, match="from_share"):
         diff(remote_state, manifest)
 
 

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -38,6 +38,7 @@ from snowcap.data_provider import (
     fetch_database,
     fetch_grant,
     fetch_shared_database,
+    fetch_security_integration,
     fetch_warehouse,
     fetch_streamlit,
     list_resource,
@@ -1174,6 +1175,128 @@ class TestFetchWarehouse:
                 continue
             assert result[field_name] == value, field_name
         assert "query_throughput_multiplier" not in result
+
+
+def _security_integration_show_row(**overrides):
+    row = {
+        "name": "CUSTOM_OAUTH",
+        "type": "OAUTH - CUSTOM",
+        "enabled": "true",
+        "comment": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def _custom_oauth_desc_rows(blocked_roles_list="[]", pre_authorized_roles_list="[]"):
+    def row(property, value, property_type):
+        return {"property": property, "property_value": value, "property_type": property_type}
+
+    return [
+        row("OAUTH_CLIENT_TYPE", "CONFIDENTIAL", "String"),
+        row("OAUTH_REDIRECT_URI", "https://example.com/callback", "String"),
+        row("OAUTH_ISSUE_REFRESH_TOKENS", "true", "Boolean"),
+        row("OAUTH_REFRESH_TOKEN_VALIDITY", "7776000", "Long"),
+        row("OAUTH_USE_SECONDARY_ROLES", "NONE", "String"),
+        row("OAUTH_ENFORCE_PKCE", "false", "Boolean"),
+        row("NETWORK_POLICY", "", "String"),
+        row("PRE_AUTHORIZED_ROLES_LIST", pre_authorized_roles_list, "List"),
+        row("BLOCKED_ROLES_LIST", blocked_roles_list, "List"),
+    ]
+
+
+class TestFetchSecurityIntegration:
+    """Tests for fetch_security_integration's OAUTH branch."""
+
+    def _mock_execute(self, desc_rows, show_row=None):
+        show_row = show_row or _security_integration_show_row()
+
+        def execute(session, sql, cacheable=False):
+            if sql.startswith("SHOW SECURITY INTEGRATIONS"):
+                return [show_row]
+            return desc_rows
+
+        return execute
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_admin_only_blocked_roles_normalizes_to_none(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            _custom_oauth_desc_rows(blocked_roles_list="[ACCOUNTADMIN, SECURITYADMIN]")
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["blocked_roles_list"] is None
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_blocked_roles_strips_admin_roles(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            _custom_oauth_desc_rows(blocked_roles_list="[ACCOUNTADMIN, SECURITYADMIN, SYSADMIN]")
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["blocked_roles_list"] == ["SYSADMIN"]
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_blocked_roles_sorted_regardless_of_desc_order(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            _custom_oauth_desc_rows(blocked_roles_list="[SECURITYADMIN, SYSADMIN, ACCOUNTADMIN, ANALYST]")
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["blocked_roles_list"] == ["ANALYST", "SYSADMIN"]
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_empty_pre_authorized_roles_normalizes_to_none(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(_custom_oauth_desc_rows())
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["pre_authorized_roles_list"] is None
+        assert result["oauth_client"] == "CUSTOM"
+        assert result["oauth_refresh_token_validity"] == 7776000
+        assert result["network_policy"] is None
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_snowservices_ingress_still_fetches_as_before(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            desc_rows=[],
+            show_row=_security_integration_show_row(name="SNOWSERVICES", type="OAUTH - SNOWSERVICES_INGRESS"),
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("SNOWSERVICES")))
+
+        assert result == {
+            "name": "SNOWSERVICES",
+            "type": "OAUTH",
+            "oauth_client": "SNOWSERVICES_INGRESS",
+            "enabled": True,
+            "owner": "ACCOUNTADMIN",
+        }
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_unsupported_oauth_client_raises(self, mock_execute, mock_fetch_owner):
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            desc_rows=[],
+            show_row=_security_integration_show_row(name="TABLEAU", type="OAUTH - TABLEAU_DESKTOP"),
+        )
+
+        with pytest.raises(Exception, match="Unsupported security integration type"):
+            fetch_security_integration(MagicMock(), FQN(name=ResourceName("TABLEAU")))
 
 
 class TestListResource:

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -1256,6 +1256,39 @@ class TestFetchSecurityIntegration:
 
     @patch("snowcap.data_provider._fetch_owner")
     @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_quoted_roles_canonicalized_like_spec(self, mock_execute, mock_fetch_owner):
+        """A quoted, case-sensitive role from DESC must canonicalize exactly like the
+        spec side (_canonicalize_role_name), or it would drift on every plan."""
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            _custom_oauth_desc_rows(
+                blocked_roles_list='[ACCOUNTADMIN, "my_role", SYSADMIN]',
+                pre_authorized_roles_list='["my_role", ANALYST]',
+            )
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        # The quote characters are stripped and the case-sensitive name keeps its case,
+        # matching what the spec produces for blocked_roles_list=['"my_role"', ...].
+        assert result["blocked_roles_list"] == ["SYSADMIN", "my_role"]
+        assert result["pre_authorized_roles_list"] == ["ANALYST", "my_role"]
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_lowercase_roles_canonicalized_like_spec(self, mock_execute, mock_fetch_owner):
+        """An unquoted role from DESC is uppercased, matching the spec side."""
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        mock_execute.side_effect = self._mock_execute(
+            _custom_oauth_desc_rows(blocked_roles_list="[ACCOUNTADMIN, sysadmin]")
+        )
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["blocked_roles_list"] == ["SYSADMIN"]
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
     def test_custom_oauth_empty_pre_authorized_roles_normalizes_to_none(self, mock_execute, mock_fetch_owner):
         mock_fetch_owner.return_value = "ACCOUNTADMIN"
         mock_execute.side_effect = self._mock_execute(_custom_oauth_desc_rows())

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -1302,6 +1302,19 @@ class TestFetchSecurityIntegration:
 
     @patch("snowcap.data_provider._fetch_owner")
     @patch("snowcap.data_provider.execute")
+    def test_custom_oauth_omitted_refresh_token_validity_degrades_to_none(self, mock_execute, mock_fetch_owner):
+        """If DESC omits OAUTH_REFRESH_TOKEN_VALIDITY, fetch must return None
+        instead of raising KeyError, like every sibling field."""
+        mock_fetch_owner.return_value = "ACCOUNTADMIN"
+        desc_rows = [row for row in _custom_oauth_desc_rows() if row["property"] != "OAUTH_REFRESH_TOKEN_VALIDITY"]
+        mock_execute.side_effect = self._mock_execute(desc_rows)
+
+        result = fetch_security_integration(MagicMock(), FQN(name=ResourceName("CUSTOM_OAUTH")))
+
+        assert result["oauth_refresh_token_validity"] is None
+
+    @patch("snowcap.data_provider._fetch_owner")
+    @patch("snowcap.data_provider.execute")
     def test_snowservices_ingress_still_fetches_as_before(self, mock_execute, mock_fetch_owner):
         mock_fetch_owner.return_value = "ACCOUNTADMIN"
         mock_execute.side_effect = self._mock_execute(

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1461,3 +1461,123 @@ class TestDropMCPServer:
         result = drop_resource(urn, {}, if_exists=True)
 
         assert result == "DROP MCP SERVER IF EXISTS MY_DB.MY_SCHEMA.MY_SERVER"
+
+
+# ============================================================================
+# Test SnowflakeCustomOAuthSecurityIntegration lifecycle
+# ============================================================================
+
+
+class TestCreateSnowflakeCustomOAuthSecurityIntegration:
+    """create_sql, the OAUTH/CUSTOM resolver, and field validation for SnowflakeCustomOAuthSecurityIntegration."""
+
+    def test_resolver_returns_custom_class(self):
+        """The OAUTH/CUSTOM resolver branch must no longer raise NotImplementedError."""
+        resource_cls = res.Resource.resolve_resource_cls(
+            ResourceType.SECURITY_INTEGRATION, {"type": "OAUTH", "oauth_client": "CUSTOM"}
+        )
+        assert resource_cls is res.SnowflakeCustomOAuthSecurityIntegration
+
+    def test_missing_oauth_client_type_raises(self):
+        """oauth_client_type is required at CREATE."""
+        with pytest.raises(ValueError):
+            res.SnowflakeCustomOAuthSecurityIntegration(
+                name="TEST_INTEGRATION", oauth_redirect_uri="https://example.com/cb"
+            )
+
+    def test_missing_oauth_redirect_uri_raises(self):
+        """oauth_redirect_uri is required at CREATE."""
+        with pytest.raises(ValueError):
+            res.SnowflakeCustomOAuthSecurityIntegration(name="TEST_INTEGRATION", oauth_client_type="CONFIDENTIAL")
+
+    def test_string_and_enum_oauth_client_type_produce_same_dict(self):
+        """oauth_client_type accepts either the raw string or the enum member."""
+        from snowcap.resources.security_integration import OAuthClientType, OAuthUseSecondaryRoles
+
+        by_string = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="TEST_INTEGRATION", oauth_client_type="CONFIDENTIAL", oauth_redirect_uri="https://example.com/cb"
+        )
+        by_enum = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="TEST_INTEGRATION",
+            oauth_client_type=OAuthClientType.CONFIDENTIAL,
+            oauth_redirect_uri="https://example.com/cb",
+        )
+        assert by_string.to_dict() == by_enum.to_dict()
+        assert by_string._data.oauth_use_secondary_roles == OAuthUseSecondaryRoles.NONE
+
+    def test_role_lists_are_sorted(self):
+        """pre_authorized_roles_list and blocked_roles_list must be canonicalized to sorted order."""
+        integration = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="TEST_INTEGRATION",
+            oauth_client_type="CONFIDENTIAL",
+            oauth_redirect_uri="https://example.com/cb",
+            pre_authorized_roles_list=["SYSADMIN", "ANALYST"],
+            blocked_roles_list=["SYSADMIN", "ANALYST"],
+        )
+        data = integration.to_dict()
+        assert data["pre_authorized_roles_list"] == ["ANALYST", "SYSADMIN"]
+        assert data["blocked_roles_list"] == ["ANALYST", "SYSADMIN"]
+
+    def test_role_lists_are_case_normalized(self):
+        """Unquoted role names are uppercased so a lowercase manifest doesn't drift against DESC."""
+        integration = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="TEST_INTEGRATION",
+            oauth_client_type="CONFIDENTIAL",
+            oauth_redirect_uri="https://example.com/cb",
+            blocked_roles_list=["sysadmin"],
+        )
+        assert integration.to_dict()["blocked_roles_list"] == ["SYSADMIN"]
+
+    def test_blocked_roles_list_rejects_always_blocked_roles(self):
+        """ACCOUNTADMIN/ORGADMIN/GLOBALORGADMIN/SECURITYADMIN are always blocked by Snowflake
+        and must not be listed, or every plan/apply would see a perpetual delta."""
+        with pytest.raises(ValueError):
+            res.SnowflakeCustomOAuthSecurityIntegration(
+                name="TEST_INTEGRATION",
+                oauth_client_type="CONFIDENTIAL",
+                oauth_redirect_uri="https://example.com/cb",
+                blocked_roles_list=["ACCOUNTADMIN", "SYSADMIN"],
+            )
+
+    def test_create_sql(self):
+        """CREATE SECURITY INTEGRATION renders every field, with a quoted client type and parenthesized quoted lists."""
+        integration = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="CLAUDE_MCP_OAUTH",
+            enabled=True,
+            oauth_client_type="CONFIDENTIAL",
+            oauth_redirect_uri="https://example.com/cb",
+            oauth_alternate_redirect_uris=["https://example.com/cb2"],
+            oauth_issue_refresh_tokens=True,
+            oauth_refresh_token_validity=7776000,
+            oauth_use_secondary_roles="NONE",
+            oauth_enforce_pkce=True,
+            blocked_roles_list=["SYSADMIN", "ANALYST"],
+            comment="test comment",
+        )
+        sql = integration.create_sql()
+        assert sql == (
+            "CREATE SECURITY INTEGRATION CLAUDE_MCP_OAUTH type = OAUTH ENABLED = TRUE "
+            "oauth_client = CUSTOM oauth_client_type = 'CONFIDENTIAL' "
+            "OAUTH_REDIRECT_URI = $$https://example.com/cb$$ "
+            "OAUTH_ALTERNATE_REDIRECT_URIS = ($$https://example.com/cb2$$) "
+            "OAUTH_ISSUE_REFRESH_TOKENS = TRUE OAUTH_REFRESH_TOKEN_VALIDITY = 7776000 "
+            "oauth_use_secondary_roles = NONE OAUTH_ENFORCE_PKCE = TRUE "
+            "BLOCKED_ROLES_LIST = ($$ANALYST$$, $$SYSADMIN$$) COMMENT = $$test comment$$"
+        )
+
+
+class TestUpdateSnowflakeCustomOAuthSecurityIntegration:
+    """update_set_sql and replacement/fetchable metadata for SnowflakeCustomOAuthSecurityIntegration."""
+
+    def test_metadata(self):
+        """oauth_client_type triggers replacement; oauth_alternate_redirect_uris is create-only."""
+        spec = res.SnowflakeCustomOAuthSecurityIntegration.spec
+        assert spec.get_metadata("oauth_client_type").triggers_replacement is True
+        assert spec.get_metadata("oauth_alternate_redirect_uris").fetchable is False
+
+    def test_update_set_sql(self):
+        """A single-field delta renders as ALTER SECURITY INTEGRATION ... SET, never CREATE OR REPLACE."""
+        urn = make_urn(ResourceType.SECURITY_INTEGRATION, "CLAUDE_MCP_OAUTH")
+        data = {"oauth_refresh_token_validity": 86400}
+        result = update_resource(urn, data, res.SnowflakeCustomOAuthSecurityIntegration.props)
+        assert result == "ALTER SECURITY INTEGRATION CLAUDE_MCP_OAUTH SET OAUTH_REFRESH_TOKEN_VALIDITY = 86400"

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1528,6 +1528,20 @@ class TestCreateSnowflakeCustomOAuthSecurityIntegration:
         )
         assert integration.to_dict()["blocked_roles_list"] == ["SYSADMIN"]
 
+    def test_quoted_role_names_keep_case(self):
+        """A quoted, case-sensitive role keeps its case (quotes stripped), matching
+        what the fetch side produces for the same role."""
+        integration = res.SnowflakeCustomOAuthSecurityIntegration(
+            name="TEST_INTEGRATION",
+            oauth_client_type="CONFIDENTIAL",
+            oauth_redirect_uri="https://example.com/cb",
+            pre_authorized_roles_list=['"my_role"', "ANALYST"],
+            blocked_roles_list=['"my_role"', "SYSADMIN"],
+        )
+        data = integration.to_dict()
+        assert data["pre_authorized_roles_list"] == ["ANALYST", "my_role"]
+        assert data["blocked_roles_list"] == ["SYSADMIN", "my_role"]
+
     def test_blocked_roles_list_rejects_always_blocked_roles(self):
         """ACCOUNTADMIN/ORGADMIN/GLOBALORGADMIN/SECURITYADMIN are always blocked by Snowflake
         and must not be listed, or every plan/apply would see a perpetual delta."""
@@ -1572,7 +1586,10 @@ class TestUpdateSnowflakeCustomOAuthSecurityIntegration:
     def test_metadata(self):
         """oauth_client_type triggers replacement; oauth_alternate_redirect_uris is create-only."""
         spec = res.SnowflakeCustomOAuthSecurityIntegration.spec
-        assert spec.get_metadata("oauth_client_type").triggers_replacement is True
+        oauth_client_type_metadata = spec.get_metadata("oauth_client_type")
+        assert oauth_client_type_metadata.triggers_replacement is True
+        # The plan-time error must explain why snowcap refuses to recreate.
+        assert "client_id and client_secret" in oauth_client_type_metadata.replacement_message
         assert spec.get_metadata("oauth_alternate_redirect_uris").fetchable is False
 
     def test_update_set_sql(self):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -10,6 +10,7 @@ from snowcap.blueprint import (
     diff,
 )
 from snowcap.enums import AccountEdition, ResourceType
+from snowcap.exceptions import MarkedForReplacementException
 from snowcap.identifiers import parse_URN
 
 
@@ -82,6 +83,29 @@ def test_plan_remove_action(session_ctx, remote_state):
     change = plan[0]
     assert isinstance(change, DropResource)
     assert change.urn == parse_URN("urn::ABCD123:role/REMOVED_ROLE")
+
+
+def test_plan_oauth_client_type_change_raises_targeted_error(session_ctx, remote_state):
+    """Changing oauth_client_type must fail the plan with an error that explains
+    recreation would rotate the Snowflake-issued client_id/client_secret."""
+    bp = Blueprint(
+        resources=[
+            res.SnowflakeCustomOAuthSecurityIntegration(
+                name="CUSTOM_OAUTH",
+                oauth_client_type="PUBLIC",
+                oauth_redirect_uri="https://example.com/cb",
+            )
+        ]
+    )
+    manifest = bp.generate_manifest(session_ctx)
+    urn = parse_URN("urn::ABCD123:security_integration/CUSTOM_OAUTH")
+    remote_state[urn] = dict(manifest[urn].data, oauth_client_type="CONFIDENTIAL")
+
+    with pytest.raises(
+        MarkedForReplacementException,
+        match="changing 'oauth_client_type' requires replacing the resource.*rotates the Snowflake-issued client_id and client_secret",
+    ):
+        diff(remote_state, manifest)
 
 
 def test_plan_no_removes_in_resources_not_in_sync_resources(session_ctx, remote_state):


### PR DESCRIPTION
## Summary
Implements `SnowflakeCustomOAuthSecurityIntegration` (TYPE = OAUTH, OAUTH_CLIENT = CUSTOM), closing #29. Custom OAuth clients — e.g. Claude.ai's Snowflake MCP connector — can now be managed declaratively instead of via manual SQL. Property changes are always applied with `ALTER SECURITY INTEGRATION`; the lifecycle never recreates the integration, which would rotate the Snowflake-issued `client_id`/`client_secret` and break live clients.

## Changes
- New `SnowflakeCustomOAuthSecurityIntegration` resource supporting `oauth_client_type`, `oauth_redirect_uri`, `oauth_alternate_redirect_uris`, `oauth_issue_refresh_tokens`, `oauth_refresh_token_validity`, `oauth_use_secondary_roles`, `oauth_enforce_pkce`, `network_policy`, `pre_authorized_roles_list`, `blocked_roles_list`; `_resolver` no longer raises `NotImplementedError` for `OAuthClient.CUSTOM`
- Immutable `oauth_client_type` is marked `triggers_replacement`, so changing it fails at plan time rather than emitting an ALTER Snowflake rejects (and never auto-recreates)
- `fetch_security_integration` gains a CUSTOM arm with drift-free normalization: role lists case-canonicalized and sorted on both sides, always-blocked admin roles (`ALWAYS_BLOCKED_OAUTH_ROLES` in `builtins.py`, enforced with a `ValueError` on the spec side) stripped from DESC output, empty values mapped to `None`
- `oauth_alternate_redirect_uris` is create-only (`fetchable=False`; DESC support unconfirmed) and documented as such
- Tests: JSON fixture auto-enrolled in the polymorphic resolver test, lifecycle unit tests (exact CREATE/ALTER SQL, validation, metadata), mocked fetch tests through the real DESC-parsing path, and a live integration round-trip test (`--snowflake`)
- Docs page `docs/resources/snowflake_custom_oauth_security_integration.md` generated from the class docstring, wired into `mkdocs.yml` nav and `docs/SUMMARY.md`

## Testing
- `pytest tests/ --ignore=tests/integration` → 1552 passed
- Live round-trip (`pytest tests/integration/data_provider/test_fetch_resource.py -k custom_oauth --snowflake`) still needs a run against a test account with `CREATE INTEGRATION ON ACCOUNT`