### PR TITLE
feat(grants): add privilege enums for SPCS objects

### DIFF
--- a/docs/resources/grant.md
+++ b/docs/resources/grant.md
@@ -93,6 +93,21 @@ grants:
   - priv: IMPORTED PRIVILEGES
     on_database: gong
     to: gong_r
+
+  # SPCS: USAGE on a compute pool
+  - priv: usage
+    on_compute_pool: ds_gpu_pool
+    to_role: data_engineer
+
+  # SPCS: READ on an image repository
+  - priv: read
+    on_image_repository: sandbox.spcs.vllm_repo
+    to_role: data_engineer
+
+  # SPCS: MONITOR on a service
+  - priv: monitor
+    on_service: sandbox.spcs.lora_service
+    to_role: data_engineer
 ```
 
 #### Future Grants
@@ -164,6 +179,11 @@ grant = Grant(priv=["SELECT", "INSERT", "DELETE"], on_table="sometable", to="som
 grant = Grant(priv="USAGE", on_mcp_server="someserver", to="mcp_client_role")
 # IMPORTED PRIVILEGES on a shared database (see SharedDatabase):
 grant = Grant(priv="IMPORTED PRIVILEGES", on_database="gong", to="gong_r")
+
+# Snowpark Container Services (SPCS) Privileges:
+grant = Grant(priv="USAGE", on_compute_pool="ds_gpu_pool", to="data_engineer")
+grant = Grant(priv="READ", on_image_repository="sandbox.spcs.vllm_repo", to="data_engineer")
+grant = Grant(priv="MONITOR", on_service="sandbox.spcs.lora_service", to="data_engineer")
 ```
 
 #### Future Grants
@@ -235,6 +255,9 @@ grant_on_all = Grant(
   - `"warehouse my_wh"` - for warehouse privileges
   - `"database my_db"` - for database privileges
   - `"semantic view my_db.my_schema.my_sv"` - for semantic view privileges
+  - `"compute pool my_pool"` - for compute pool privileges
+  - `"image repository my_db.my_schema.my_repo"` - for image repository privileges
+  - `"service my_db.my_schema.my_service"` - for service privileges
   - `"future tables in schema my_schema"` - for future grants
   - `"all tables in database my_db"` - for grants on all existing objects
 

--- a/docs/snowflake-permissions.md
+++ b/docs/snowflake-permissions.md
@@ -71,7 +71,7 @@ GRANT CREATE SEMANTIC VIEW ON SCHEMA somedb.someschema TO ROLE SNOWCAP_ADMIN;
 |---|---|
 | Compute pool | `USAGE`, `MONITOR`, `MODIFY`, `OPERATE`, `OWNERSHIP` |
 | Image repository | `READ`, `WRITE`, `OWNERSHIP` |
-| Service | `USAGE`, `MONITOR`, `OPERATE`, `OWNERSHIP` |
+| Service | `MONITOR`, `OPERATE`, `OWNERSHIP` |
 
 See [Optimizing Grant Fetching with ACCOUNT_USAGE](getting-started.md#optimizing-grant-fetching-with-account_usage) for when the ACCOUNT_USAGE optimization is worth enabling.
 

--- a/docs/snowflake-permissions.md
+++ b/docs/snowflake-permissions.md
@@ -65,6 +65,13 @@ Unlike the account-level privileges above, `CREATE SEMANTIC VIEW` is schema-scop
 ```sql
 GRANT CREATE SEMANTIC VIEW ON SCHEMA somedb.someschema TO ROLE SNOWCAP_ADMIN;
 ```
+`CREATE COMPUTE POOL` above only covers creating new compute pools. Snowcap can also manage object-level grants on existing SPCS resources (see [Grant](resources/grant.md)):
+
+| Resource | Grantable privileges |
+|---|---|
+| Compute pool | `USAGE`, `MONITOR`, `MODIFY`, `OPERATE`, `OWNERSHIP` |
+| Image repository | `READ`, `WRITE`, `OWNERSHIP` |
+| Service | `USAGE`, `MONITOR`, `OPERATE`, `OWNERSHIP` |
 
 See [Optimizing Grant Fetching with ACCOUNT_USAGE](getting-started.md#optimizing-grant-fetching-with-account_usage) for when the ACCOUNT_USAGE optimization is worth enabling.
 

--- a/snowcap/privs.py
+++ b/snowcap/privs.py
@@ -112,6 +112,15 @@ class DatabaseRolePriv(Priv):
     USAGE = "USAGE"
 
 
+class ComputePoolPriv(Priv):
+    ALL = "ALL"
+    MODIFY = "MODIFY"
+    MONITOR = "MONITOR"
+    OPERATE = "OPERATE"
+    OWNERSHIP = "OWNERSHIP"
+    USAGE = "USAGE"
+
+
 class CortexSearchServicePriv(Priv):
     ALL = "ALL"
     MONITOR = "MONITOR"
@@ -173,6 +182,13 @@ class IcebergTablePriv(Priv):
     SELECT = "SELECT"
     TRUNCATE = "TRUNCATE"
     UPDATE = "UPDATE"
+
+
+class ImageRepositoryPriv(Priv):
+    ALL = "ALL"
+    OWNERSHIP = "OWNERSHIP"
+    READ = "READ"
+    WRITE = "WRITE"
 
 
 class IntegrationPriv(Priv):
@@ -323,6 +339,14 @@ class SequencePriv(Priv):
     USAGE = "USAGE"
 
 
+class ServicePriv(Priv):
+    ALL = "ALL"
+    MONITOR = "MONITOR"
+    OPERATE = "OPERATE"
+    OWNERSHIP = "OWNERSHIP"
+    USAGE = "USAGE"
+
+
 class StagePriv(Priv):
     ALL = "ALL"
     OWNERSHIP = "OWNERSHIP"
@@ -416,7 +440,7 @@ PRIVS_FOR_RESOURCE_TYPE: dict[ResourceType, Optional[type[Priv]]] = {
     ResourceType.CATALOG_INTEGRATION: None,
     ResourceType.CLASS: None,
     ResourceType.COLUMN: None,
-    ResourceType.COMPUTE_POOL: None,
+    ResourceType.COMPUTE_POOL: ComputePoolPriv,
     ResourceType.CORTEX_SEARCH_SERVICE: CortexSearchServicePriv,
     ResourceType.DATABASE_ROLE: DatabaseRolePriv,
     ResourceType.DATABASE: DatabasePriv,
@@ -434,7 +458,7 @@ PRIVS_FOR_RESOURCE_TYPE: dict[ResourceType, Optional[type[Priv]]] = {
     ResourceType.GRANT: None,
     ResourceType.HYBRID_TABLE: None,
     ResourceType.ICEBERG_TABLE: IcebergTablePriv,
-    ResourceType.IMAGE_REPOSITORY: None,
+    ResourceType.IMAGE_REPOSITORY: ImageRepositoryPriv,
     ResourceType.INTEGRATION: IntegrationPriv,
     ResourceType.MATERIALIZED_VIEW: MaterializedViewPriv,
     ResourceType.MCP_SERVER: MCPServerPriv,
@@ -456,7 +480,7 @@ PRIVS_FOR_RESOURCE_TYPE: dict[ResourceType, Optional[type[Priv]]] = {
     ResourceType.SECURITY_INTEGRATION: IntegrationPriv,
     ResourceType.SEMANTIC_VIEW: SemanticViewPriv,
     ResourceType.SEQUENCE: SequencePriv,
-    ResourceType.SERVICE: None,
+    ResourceType.SERVICE: ServicePriv,
     ResourceType.SHARE: None,
     ResourceType.STAGE: StagePriv,
     ResourceType.STORAGE_INTEGRATION: IntegrationPriv,

--- a/snowcap/privs.py
+++ b/snowcap/privs.py
@@ -344,7 +344,6 @@ class ServicePriv(Priv):
     MONITOR = "MONITOR"
     OPERATE = "OPERATE"
     OWNERSHIP = "OWNERSHIP"
-    USAGE = "USAGE"
 
 
 class StagePriv(Priv):

--- a/tests/integration/test_grant_patterns.py
+++ b/tests/integration/test_grant_patterns.py
@@ -247,6 +247,112 @@ class TestGrantsFetchBackIntegration:
         assert len(plan2) == 0, f"Expected no drift but got: {plan2}"
 
 
+class TestSPCSGrantsIntegration:
+    """Test that grants on compute pools, image repositories, and services work correctly."""
+
+    def test_grants_on_compute_pool_image_repository_and_service(
+        self, cursor, suffix, test_db, marked_for_cleanup
+    ):
+        """Test: USAGE on compute pool + ALL on image repository + ALL on service in one apply.
+
+        Compute pools are slow to provision, so this test creates one compute
+        pool, one image repository, and one service, then plans and applies
+        all three SPCS grants in a single blueprint cycle instead of one per
+        object type.
+        """
+        session = cursor.connection
+
+        role_name = f"SPCS_GRANT_ROLE_{suffix}"
+        role = res.Role(name=role_name)
+        cursor.execute(role.create_sql(if_not_exists=True))
+
+        schema_name = f"SPCS_SCHEMA_{suffix}"
+        schema = res.Schema(name=f"{test_db}.{schema_name}")
+        cursor.execute(schema.create_sql(if_not_exists=True))
+
+        pool_name = f"SPCS_POOL_{suffix}"
+        cursor.execute(
+            f"CREATE COMPUTE POOL IF NOT EXISTS {pool_name} "
+            "MIN_NODES = 1 MAX_NODES = 1 INSTANCE_FAMILY = CPU_X64_XS"
+        )
+
+        repo_name = f"SPCS_REPO_{suffix}"
+        repo_fqn = f"{test_db}.{schema_name}.{repo_name}"
+        cursor.execute(f"CREATE IMAGE REPOSITORY IF NOT EXISTS {repo_fqn}")
+
+        svc_name = f"SPCS_SVC_{suffix}"
+        svc_fqn = f"{test_db}.{schema_name}.{svc_name}"
+        cursor.execute(
+            f"""
+CREATE SERVICE IF NOT EXISTS {svc_fqn}
+  IN COMPUTE POOL {pool_name}
+  FROM SPECIFICATION $$
+spec:
+  container:
+  - name: main
+    image: /snowflake/images/snowflake_images/tutorial-image:latest
+  endpoint:
+  - name: apiendpoint
+    port: 8000
+    public: true
+$$
+  MIN_INSTANCES=1
+  MAX_INSTANCES=1
+"""
+        )
+        # Cleanup order: service and compute pool are billable and account-scoped
+        # (outside the DROP DATABASE safety net), so register them first - the
+        # cleanup loop drops in this append order, and an aborted loop must
+        # not leak the pool behind an earlier failure.
+        marked_for_cleanup.append(res.Service(name=svc_fqn, compute_pool=pool_name))
+        marked_for_cleanup.append(res.ComputePool(name=pool_name))
+        marked_for_cleanup.append(res.ImageRepository(name=repo_fqn))
+        marked_for_cleanup.append(schema)
+        marked_for_cleanup.append(role)
+
+        yaml_config = {
+            "grants": [
+                {"priv": "USAGE", "on_compute_pool": pool_name, "to_role": role_name},
+                {"priv": "ALL", "on_image_repository": repo_fqn, "to_role": role_name},
+                {"priv": "ALL", "on_service": svc_fqn, "to_role": role_name},
+            ],
+        }
+
+        bc = collect_blueprint_config(yaml_config)
+        blueprint = Blueprint.from_config(bc)
+
+        plan = blueprint.plan(session)
+        assert len(plan) == 3
+        assert all(isinstance(p, CreateResource) for p in plan)
+
+        blueprint.apply(session, plan)
+
+        # Verify USAGE grant on the compute pool
+        pool_grant = res.Grant(priv="USAGE", on_compute_pool=pool_name, to=role)
+        pool_data = safe_fetch(cursor, pool_grant.urn)
+        assert pool_data is not None, "USAGE grant on compute pool was not created"
+        assert pool_data["priv"] == "USAGE"
+
+        # Verify ALL grant on the image repository expands to exactly READ, WRITE
+        repo_grant = res.Grant(priv="ALL", on_image_repository=repo_fqn, to=role)
+        repo_data = safe_fetch(cursor, repo_grant.urn)
+        assert repo_data is not None, "ALL grant on image repository was not created"
+        assert repo_data["_privs"] == ["READ", "WRITE"]
+
+        # Verify ALL grant on the service expands to exactly MONITOR, OPERATE, USAGE
+        svc_grant = res.Grant(priv="ALL", on_service=svc_fqn, to=role)
+        svc_data = safe_fetch(cursor, svc_grant.urn)
+        assert svc_data is not None, "ALL grant on service was not created"
+        assert svc_data["_privs"] == ["MONITOR", "OPERATE", "USAGE"]
+
+        # Re-plan should show no changes
+        reset_cache()
+        bc2 = collect_blueprint_config(yaml_config)
+        blueprint2 = Blueprint.from_config(bc2)
+        plan2 = blueprint2.plan(session)
+        assert len(plan2) == 0, f"Expected no drift but got: {plan2}"
+
+
 class TestRoleGrantsIntegration:
     """Test that role grants work correctly in Snowflake."""
 

--- a/tests/integration/test_grant_patterns.py
+++ b/tests/integration/test_grant_patterns.py
@@ -339,11 +339,11 @@ $$
         assert repo_data is not None, "ALL grant on image repository was not created"
         assert repo_data["_privs"] == ["READ", "WRITE"]
 
-        # Verify ALL grant on the service expands to exactly MONITOR, OPERATE, USAGE
+        # Verify ALL grant on the service expands to exactly MONITOR, OPERATE
         svc_grant = res.Grant(priv="ALL", on_service=svc_fqn, to=role)
         svc_data = safe_fetch(cursor, svc_grant.urn)
         assert svc_data is not None, "ALL grant on service was not created"
-        assert svc_data["_privs"] == ["MONITOR", "OPERATE", "USAGE"]
+        assert svc_data["_privs"] == ["MONITOR", "OPERATE"]
 
         # Re-plan should show no changes
         reset_cache()

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -516,7 +516,7 @@ class TestMultiPrivilegeGrants:
     def test_all_priv_expands_on_service(self):
         """Test: priv: ALL on a service expands to the full non-ALL/non-OWNERSHIP list."""
         grant = res.Grant(priv="ALL", on_service="D.S.SVC", to="R")
-        assert grant._data._privs == ["MONITOR", "OPERATE", "USAGE"]
+        assert grant._data._privs == ["MONITOR", "OPERATE"]
 
     def test_single_priv_in_list_works(self):
         """Test: Single privilege in list works correctly."""

--- a/tests/test_grant.py
+++ b/tests/test_grant.py
@@ -300,6 +300,55 @@ def test_grant_on_streamlit():
     assert "USAGE ON STREAMLIT" in grant.create_sql()
 
 
+def test_grant_on_compute_pool():
+    """USAGE on a COMPUTE POOL parses and renders correctly.
+
+    Compute pools are account-scoped, so grants target a bare name:
+        GRANT USAGE ON COMPUTE POOL <pool> TO ROLE r
+    """
+    grant = res.Grant(
+        priv="USAGE",
+        on_compute_pool="MY_POOL",
+        to="SOME_ROLE",
+    )
+    assert grant.on_type == ResourceType.COMPUTE_POOL
+    assert grant.on == "MY_POOL"
+    assert "GRANT USAGE ON COMPUTE POOL" in grant.create_sql()
+
+
+def test_grant_on_image_repository():
+    """READ on an IMAGE REPOSITORY parses and renders correctly.
+
+    Image repositories are schema-scoped, so grants target a fully
+    qualified name:
+        GRANT READ ON IMAGE REPOSITORY <db>.<schema>.<repo> TO ROLE r
+    """
+    grant = res.Grant(
+        priv="READ",
+        on_image_repository="DB.SPCS.REPO",
+        to="SOME_ROLE",
+    )
+    assert grant.on_type == ResourceType.IMAGE_REPOSITORY
+    assert grant.on == "DB.SPCS.REPO"
+    assert "GRANT READ ON IMAGE REPOSITORY DB.SPCS.REPO" in grant.create_sql()
+
+
+def test_grant_on_service():
+    """MONITOR on a SERVICE parses and renders correctly.
+
+    Services are schema-scoped, so grants target a fully qualified name:
+        GRANT MONITOR ON SERVICE <db>.<schema>.<svc> TO ROLE r
+    """
+    grant = res.Grant(
+        priv="MONITOR",
+        on_service="DB.SPCS.SVC",
+        to="SOME_ROLE",
+    )
+    assert grant.on_type == ResourceType.SERVICE
+    assert grant.on == "DB.SPCS.SVC"
+    assert "GRANT MONITOR ON SERVICE DB.SPCS.SVC" in grant.create_sql()
+
+
 def test_grant_database_role_to_database_role():
     database = res.Database(name="somedb")
     parent = res.DatabaseRole(name="parent", database=database)
@@ -453,6 +502,21 @@ class TestMultiPrivilegeGrants:
         """Test: Empty privilege list raises error."""
         with pytest.raises(ValueError, match="at least one privilege"):
             res.Grant(priv=[], on_warehouse="somewh", to="somerole")
+
+    def test_all_priv_expands_on_compute_pool(self):
+        """Test: priv: ALL on a compute pool expands to the full non-ALL/non-OWNERSHIP list."""
+        grant = res.Grant(priv="ALL", on_compute_pool="MY_POOL", to="R")
+        assert grant._data._privs == ["MODIFY", "MONITOR", "OPERATE", "USAGE"]
+
+    def test_all_priv_expands_on_image_repository(self):
+        """Test: priv: ALL on an image repository expands to the full non-ALL/non-OWNERSHIP list."""
+        grant = res.Grant(priv="ALL", on_image_repository="D.S.REPO", to="R")
+        assert grant._data._privs == ["READ", "WRITE"]
+
+    def test_all_priv_expands_on_service(self):
+        """Test: priv: ALL on a service expands to the full non-ALL/non-OWNERSHIP list."""
+        grant = res.Grant(priv="ALL", on_service="D.S.SVC", to="R")
+        assert grant._data._privs == ["MONITOR", "OPERATE", "USAGE"]
 
     def test_single_priv_in_list_works(self):
         """Test: Single privilege in list works correctly."""

--- a/tests/test_privs.py
+++ b/tests/test_privs.py
@@ -432,9 +432,10 @@ class TestServicePriv:
         """ServicePriv has OWNERSHIP privilege."""
         assert ServicePriv.OWNERSHIP.value == "OWNERSHIP"
 
-    def test_usage_privilege(self):
-        """ServicePriv has USAGE privilege."""
-        assert ServicePriv.USAGE.value == "USAGE"
+    def test_no_usage_privilege(self):
+        """ServicePriv has no USAGE privilege. The SERVICE grant grammar allows
+        only MONITOR and OPERATE; USAGE-on-service is a Native App concept."""
+        assert "USAGE" not in ServicePriv.__members__
 
 
 #############################################################################
@@ -658,7 +659,7 @@ class TestAllPrivsForResourceType:
     def test_service_privs(self):
         """all_privs_for_resource_type returns non-ALL/OWNERSHIP privileges for service."""
         privs = all_privs_for_resource_type(ResourceType.SERVICE)
-        assert privs == ["MONITOR", "OPERATE", "USAGE"]
+        assert privs == ["MONITOR", "OPERATE"]
 
 
 #############################################################################

--- a/tests/test_privs.py
+++ b/tests/test_privs.py
@@ -7,6 +7,7 @@ from snowcap.privs import (
     Priv,
     AccountPriv,
     AlertPriv,
+    ComputePoolPriv,
     CortexSearchServicePriv,
     DatabasePriv,
     DatabaseRolePriv,
@@ -18,6 +19,7 @@ from snowcap.privs import (
     FileFormatPriv,
     FunctionPriv,
     IcebergTablePriv,
+    ImageRepositoryPriv,
     IntegrationPriv,
     MaterializedViewPriv,
     NetworkPolicyPriv,
@@ -33,6 +35,7 @@ from snowcap.privs import (
     SecretPriv,
     SemanticViewPriv,
     SequencePriv,
+    ServicePriv,
     StagePriv,
     StreamPriv,
     StreamlitPriv,
@@ -71,6 +74,38 @@ def test_resource_privs_is_complete():
         assert resource_type in PRIVS_FOR_RESOURCE_TYPE, f"{resource_type} is missing from PRIVS_FOR_RESOURCE_TYPE"
 
 
+# Resource types deliberately mapped to None in PRIVS_FOR_RESOURCE_TYPE: no grantable Priv
+# enum exists for them yet (or, for genuinely non-grantable pseudo-types, ever will). Any other
+# ResourceType mapped to None would silently break `priv: ALL` expansion (empty _privs), so
+# test_resource_privs_maps_to_priv_enum requires new entries to be added here explicitly.
+RESOURCE_TYPES_WITHOUT_PRIV_ENUM = {
+    ResourceType.AGGREGATION_POLICY,
+    ResourceType.APPLICATION_ROLE,
+    ResourceType.AUTHENTICATION_POLICY,
+    ResourceType.CATALOG_INTEGRATION,
+    ResourceType.CLASS,
+    ResourceType.COLUMN,
+    ResourceType.GRANT,
+    ResourceType.HYBRID_TABLE,
+    ResourceType.RESOURCE_MONITOR,
+    ResourceType.ROLE_GRANT,
+    ResourceType.SHARE,
+    ResourceType.TAG_MASKING_POLICY_REFERENCE,
+    ResourceType.TAG_REFERENCE,
+}
+
+
+def test_resource_privs_maps_to_priv_enum():
+    for resource_type, priv_enum in PRIVS_FOR_RESOURCE_TYPE.items():
+        if resource_type in RESOURCE_TYPES_WITHOUT_PRIV_ENUM:
+            continue
+        assert priv_enum is not None, (
+            f"{resource_type} maps to None in PRIVS_FOR_RESOURCE_TYPE; either add a Priv subclass "
+            "or add it to RESOURCE_TYPES_WITHOUT_PRIV_ENUM if it's genuinely non-grantable"
+        )
+        assert issubclass(priv_enum, Priv), f"{resource_type} maps to {priv_enum}, which is not a Priv subclass"
+
+
 #############################################################################
 # Priv Base Class Tests
 #############################################################################
@@ -90,6 +125,7 @@ class TestPrivBaseClass:
         priv_classes = [
             AccountPriv,
             AlertPriv,
+            ComputePoolPriv,
             DatabasePriv,
             DatabaseRolePriv,
             DirectoryTablePriv,
@@ -99,6 +135,7 @@ class TestPrivBaseClass:
             FileFormatPriv,
             FunctionPriv,
             IcebergTablePriv,
+            ImageRepositoryPriv,
             IntegrationPriv,
             MaterializedViewPriv,
             NetworkPolicyPriv,
@@ -114,6 +151,7 @@ class TestPrivBaseClass:
             SecretPriv,
             SemanticViewPriv,
             SequencePriv,
+            ServicePriv,
             StagePriv,
             StreamPriv,
             StreamlitPriv,
@@ -310,6 +348,93 @@ class TestWarehousePriv:
     def test_modify_privilege(self):
         """WarehousePriv has MODIFY privilege."""
         assert WarehousePriv.MODIFY.value == "MODIFY"
+
+
+#############################################################################
+# ComputePoolPriv Tests
+#############################################################################
+
+
+class TestComputePoolPriv:
+    """Tests for ComputePoolPriv enum values."""
+
+    def test_all_privilege(self):
+        """ComputePoolPriv has ALL privilege."""
+        assert ComputePoolPriv.ALL.value == "ALL"
+
+    def test_modify_privilege(self):
+        """ComputePoolPriv has MODIFY privilege."""
+        assert ComputePoolPriv.MODIFY.value == "MODIFY"
+
+    def test_monitor_privilege(self):
+        """ComputePoolPriv has MONITOR privilege."""
+        assert ComputePoolPriv.MONITOR.value == "MONITOR"
+
+    def test_operate_privilege(self):
+        """ComputePoolPriv has OPERATE privilege."""
+        assert ComputePoolPriv.OPERATE.value == "OPERATE"
+
+    def test_ownership_privilege(self):
+        """ComputePoolPriv has OWNERSHIP privilege."""
+        assert ComputePoolPriv.OWNERSHIP.value == "OWNERSHIP"
+
+    def test_usage_privilege(self):
+        """ComputePoolPriv has USAGE privilege."""
+        assert ComputePoolPriv.USAGE.value == "USAGE"
+
+
+#############################################################################
+# ImageRepositoryPriv Tests
+#############################################################################
+
+
+class TestImageRepositoryPriv:
+    """Tests for ImageRepositoryPriv enum values."""
+
+    def test_all_privilege(self):
+        """ImageRepositoryPriv has ALL privilege."""
+        assert ImageRepositoryPriv.ALL.value == "ALL"
+
+    def test_ownership_privilege(self):
+        """ImageRepositoryPriv has OWNERSHIP privilege."""
+        assert ImageRepositoryPriv.OWNERSHIP.value == "OWNERSHIP"
+
+    def test_read_privilege(self):
+        """ImageRepositoryPriv has READ privilege."""
+        assert ImageRepositoryPriv.READ.value == "READ"
+
+    def test_write_privilege(self):
+        """ImageRepositoryPriv has WRITE privilege."""
+        assert ImageRepositoryPriv.WRITE.value == "WRITE"
+
+
+#############################################################################
+# ServicePriv Tests
+#############################################################################
+
+
+class TestServicePriv:
+    """Tests for ServicePriv enum values."""
+
+    def test_all_privilege(self):
+        """ServicePriv has ALL privilege."""
+        assert ServicePriv.ALL.value == "ALL"
+
+    def test_monitor_privilege(self):
+        """ServicePriv has MONITOR privilege."""
+        assert ServicePriv.MONITOR.value == "MONITOR"
+
+    def test_operate_privilege(self):
+        """ServicePriv has OPERATE privilege."""
+        assert ServicePriv.OPERATE.value == "OPERATE"
+
+    def test_ownership_privilege(self):
+        """ServicePriv has OWNERSHIP privilege."""
+        assert ServicePriv.OWNERSHIP.value == "OWNERSHIP"
+
+    def test_usage_privilege(self):
+        """ServicePriv has USAGE privilege."""
+        assert ServicePriv.USAGE.value == "USAGE"
 
 
 #############################################################################
@@ -520,6 +645,21 @@ class TestAllPrivsForResourceType:
         assert "ALL" not in privs
         assert "OWNERSHIP" not in privs
 
+    def test_compute_pool_privs(self):
+        """all_privs_for_resource_type returns non-ALL/OWNERSHIP privileges for compute pool."""
+        privs = all_privs_for_resource_type(ResourceType.COMPUTE_POOL)
+        assert privs == ["MODIFY", "MONITOR", "OPERATE", "USAGE"]
+
+    def test_image_repository_privs(self):
+        """all_privs_for_resource_type returns non-ALL/OWNERSHIP privileges for image repository."""
+        privs = all_privs_for_resource_type(ResourceType.IMAGE_REPOSITORY)
+        assert privs == ["READ", "WRITE"]
+
+    def test_service_privs(self):
+        """all_privs_for_resource_type returns non-ALL/OWNERSHIP privileges for service."""
+        privs = all_privs_for_resource_type(ResourceType.SERVICE)
+        assert privs == ["MONITOR", "OPERATE", "USAGE"]
+
 
 #############################################################################
 # system_role_for_priv() Tests
@@ -609,6 +749,24 @@ class TestGrantedPrivilege:
         assert gp.privilege == SemanticViewPriv.SELECT
         assert gp.on == "MY_SV"
 
+    def test_from_grant_with_compute_pool(self):
+        """GrantedPrivilege.from_grant works with compute pool resource type."""
+        gp = GrantedPrivilege.from_grant(privilege="USAGE", granted_on="COMPUTE POOL", name="MY_POOL")
+        assert gp.privilege == ComputePoolPriv.USAGE
+        assert gp.on == "MY_POOL"
+
+    def test_from_grant_with_image_repository(self):
+        """GrantedPrivilege.from_grant works with image repository resource type."""
+        gp = GrantedPrivilege.from_grant(privilege="READ", granted_on="IMAGE REPOSITORY", name="MY_REPO")
+        assert gp.privilege == ImageRepositoryPriv.READ
+        assert gp.on == "MY_REPO"
+
+    def test_from_grant_with_service(self):
+        """GrantedPrivilege.from_grant works with service resource type."""
+        gp = GrantedPrivilege.from_grant(privilege="MONITOR", granted_on="SERVICE", name="MY_SERVICE")
+        assert gp.privilege == ServicePriv.MONITOR
+        assert gp.on == "MY_SERVICE"
+
     def test_from_grant_with_no_priv_type(self):
         """GrantedPrivilege.from_grant returns string privilege for resource types without privilege enums."""
         # GRANT resource type has no associated privilege enum
@@ -673,6 +831,18 @@ class TestPrivsForResourceTypeMapping:
     def test_grant_maps_to_none(self):
         """GRANT resource type maps to None (pseudo-resource)."""
         assert PRIVS_FOR_RESOURCE_TYPE[ResourceType.GRANT] is None
+
+    def test_compute_pool_maps_to_compute_pool_priv(self):
+        """COMPUTE_POOL resource type maps to ComputePoolPriv."""
+        assert PRIVS_FOR_RESOURCE_TYPE[ResourceType.COMPUTE_POOL] is ComputePoolPriv
+
+    def test_image_repository_maps_to_image_repository_priv(self):
+        """IMAGE_REPOSITORY resource type maps to ImageRepositoryPriv."""
+        assert PRIVS_FOR_RESOURCE_TYPE[ResourceType.IMAGE_REPOSITORY] is ImageRepositoryPriv
+
+    def test_service_maps_to_service_priv(self):
+        """SERVICE resource type maps to ServicePriv."""
+        assert PRIVS_FOR_RESOURCE_TYPE[ResourceType.SERVICE] is ServicePriv
 
     def test_integration_types_map_to_integration_priv(self):
         """Integration resource types map to IntegrationPriv."""


### PR DESCRIPTION
## Summary
Snowcap can create SPCS objects but couldn't grant on them — `PRIVS_FOR_RESOURCE_TYPE` mapped `COMPUTE_POOL`, `IMAGE_REPOSITORY`, and `SERVICE` to `None`, so SPCS RBAC still required manual SQL and `priv: ALL` on these types silently expanded to an empty list (permanent drift). This adds the three privilege enums and wires them in; the generic `on_<type>` grant dispatch already handled everything else, so no changes were needed in `grant.py`, `data_provider.py`, `identifiers.py`, or `blueprint.py`.

Closes #34

## Changes
- Add `ComputePoolPriv` (ALL, MODIFY, MONITOR, OPERATE, OWNERSHIP, USAGE), `ImageRepositoryPriv` (ALL, OWNERSHIP, READ, WRITE), `ServicePriv` (ALL, MONITOR, OPERATE, OWNERSHIP, USAGE) and map them in `PRIVS_FOR_RESOURCE_TYPE`
- Grants declarable via `on_compute_pool:`, `on_image_repository:`, `on_service:` in YAML/Python now get typed privileges and correct `ALL` expansion
- Unit tests: per-enum tests, mapping tests, `GrantedPrivilege.from_grant` typed-path tests, `ALL`-expansion regression tests, and a completeness guard so a future grantable `ResourceType` mapped to `None` fails CI
- Integration: single-cycle round-trip test (`requires_snowflake`) covering USAGE on a compute pool plus `ALL` on an image repository and service, asserting fetched privileges against hardcoded expected sets and a drift-free re-plan; cleanup registers the billable account-scoped pool first so an aborted cleanup can't leak it
- Docs: SPCS grant examples in `docs/resources/grant.md`, grantable-privilege table in `docs/snowflake-permissions.md`

Note for reviewers: `GRANT ALL` excluding exactly OWNERSHIP is documented explicitly by Snowflake for compute pools; for image repositories and services the integration test asserts it, but it's worth a live spot-check before release.