### PR TITLE
ci: owner-gated integration tests via an `integration` commit status

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,9 +16,17 @@ name: Integration Tests
 #
 # NOTE: use Reject to dismiss, not Cancel — a cancelled run leaves `verdict`
 # incomplete, which keeps the PR blocked until the workflow is re-run.
+#
+# SECURITY: `pull_request_target` is used (instead of `pull_request`) so that
+# fork PRs — the normal contribution flow for this repo — can access the
+# environment secrets after approval. The workflow definition always comes
+# from the base repo; untrusted PR code is checked out and executed ONLY
+# inside the `integration` job, which cannot start until an environment
+# reviewer has approved it. Reviewers: read the PR diff (including changes to
+# conftest/tests) before approving.
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     paths:
       - "snowcap/**"
@@ -40,6 +48,10 @@ on:
           - snowflake-aws-business-critical
           - snowflake-azure-standard
           - snowflake-gcp-standard
+      pr_number:
+        description: "PR number to test (optional; default: main)"
+        required: false
+        default: ""
       pytest_args:
         description: Extra pytest args (e.g. -k warehouse)
         required: false
@@ -66,7 +78,14 @@ jobs:
         id: mark
         run: echo "started=true" >> "$GITHUB_OUTPUT"
 
+      # PR events check out the PR *merge* ref (PR code merged into main),
+      # which lives in the base repo even for fork PRs.
       - uses: actions/checkout@v4
+        with:
+          ref: >-
+            ${{ github.event_name == 'pull_request_target'
+                && format('refs/pull/{0}/merge', github.event.pull_request.number)
+                || (inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref) }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,28 +2,41 @@ name: Integration Tests
 
 # Owner-gated integration tests against a real Snowflake test account.
 #
-# Flow (requires "required reviewers" on the snowflake-* environments):
-#   - Every code PR queues an `integration` job that WAITS for an environment
-#     reviewer decision.
-#   - Approve  -> tests run. If they fail, the `verdict` job fails and blocks merge.
-#   - Reject   -> dismissed. The `verdict` job passes and the PR can merge.
-#   - No decision -> `verdict` stays pending and the PR cannot merge.
+# Merge gate: the `integration` commit status (not a required-check job).
+# `pending` posts it on PR open/push; a maintainer resolves it one of three
+# ways, and .github/workflows/integration-waiver.yml can also resolve it via
+# PR review approval:
+#   - Run    -> approve the environment deployment. Pass -> success.
+#               Fail -> failure, which blocks merge even after the PR is
+#               later approved; only a new commit (fresh pending) clears it.
+#   - Skip   -> reject the pending deployment -> success ("skipped by
+#               maintainer decision").
+#   - Waive  -> a reviewer with maintain/admin repo role approves the PR
+#               (integration-waiver.yml) -> success ("waived"), unless a
+#               failure is already recorded for this commit (sticky) or an
+#               integration run is actively executing (defers to `report`).
 #
-# `verdict` (not `integration`) is the job to mark as a required status check:
-# it distinguishes "reviewer dismissed the run" (job rejected before any step
-# ran -> outputs empty -> pass) from "tests ran and failed" (test step outcome
-# captured via continue-on-error -> fail).
+# `report` (not `integration`) posts the final status: it distinguishes
+# "unit failed / run cancelled" (nothing posted, status stays pending) from
+# "reviewer rejected the deployment" (started output empty -> success) from
+# "tests ran" (decision output from a final always() step, based on the
+# continue-on-error pytest outcome).
 #
-# NOTE: use Reject to dismiss, not Cancel — a cancelled run leaves `verdict`
-# incomplete, which keeps the PR blocked until the workflow is re-run.
+# NOTE: use Reject to dismiss a run, not Cancel — a cancelled run is
+# excluded from `report`'s logic, so the status stays pending until re-run.
 #
-# SECURITY: `pull_request_target` is used (instead of `pull_request`) so that
-# fork PRs — the normal contribution flow for this repo — can access the
-# environment secrets after approval. The workflow definition always comes
-# from the base repo; untrusted PR code is checked out and executed ONLY
-# inside the `integration` job, which cannot start until an environment
-# reviewer has approved it. Reviewers: read the PR diff (including changes to
-# conftest/tests) before approving.
+# `unit` must pass on the latest commit before `integration` becomes
+# available (needs: unit); workflow_dispatch's `force: true` overrides this.
+#
+# SECURITY: pull_request_target is used (instead of pull_request) so fork
+# PRs — the normal contribution flow for this repo — can access environment
+# secrets after approval. The workflow definition always comes from the
+# base repo. Top-level permissions are read-only; `unit` checks out
+# untrusted PR code but references no secrets; `secrets.*` is read only
+# inside the environment-gated `integration` job; `pending`/`report` never
+# check out any code and hold only statuses: write. Reviewers: read the PR
+# diff (including changes to conftest/tests) before approving the
+# deployment.
 
 on:
   pull_request_target:
@@ -56,27 +69,63 @@ on:
         description: Extra pytest args (e.g. -k warehouse)
         required: false
         default: ""
+      force:
+        description: Run integration tests even if the unit job fails
+        type: boolean
+        default: false
 
-# One run per test account at a time. A run waiting for reviewer decision can
-# hold the queue; dismiss (Reject) stale runs to release it.
-concurrency:
-  group: integration-${{ inputs.environment || 'snowflake-aws-enterprise' }}
-  cancel-in-progress: false
+permissions:
+  contents: read
 
 jobs:
-  integration:
-    name: integration
+  pending:
+    name: pending
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
-    outputs:
-      started: ${{ steps.mark.outputs.started }}
-      tests: ${{ steps.tests.outcome }}
+    permissions:
+      statuses: write
+    concurrency:
+      group: integration-status-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: false
     steps:
-      # Runs only after reviewer approval; its absence in outputs means the
-      # run was rejected (dismissed) and verdict must not block the PR.
-      - name: Mark run as approved
-        id: mark
-        run: echo "started=true" >> "$GITHUB_OUTPUT"
+      - name: Post pending status (fail closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          count=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/status" \
+            --jq '[.statuses[] | select(.context == "integration")] | length') || {
+            echo "::notice::could not read existing integration status; not posting pending (fail closed)"
+            exit 0
+          }
+          if [ "$count" -ne 0 ]; then
+            echo "::notice::integration status already recorded for this commit; not resetting"
+            exit 0
+          fi
+          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+            -f state=pending \
+            -f context=integration \
+            -f description="Waiting for a maintainer decision (run, skip, or approve the PR)" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    outputs:
+      head_sha: ${{ steps.sha.outputs.head_sha }}
+    steps:
+      - name: Resolve head sha
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            sha="${{ github.event.pull_request.head.sha }}"
+          elif [ -n "${{ inputs.pr_number }}" ]; then
+            sha=$(gh api "repos/${{ github.repository }}/pulls/${{ inputs.pr_number }}" --jq .head.sha)
+          else
+            sha=""
+          fi
+          echo "head_sha=$sha" >> "$GITHUB_OUTPUT"
 
       # PR events check out the PR *merge* ref (PR code merged into main),
       # which lives in the base repo even for fork PRs.
@@ -90,6 +139,52 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+          cache: pip
+          cache-dependency-path: setup.py
+
+      - name: Install dependencies
+        run: |
+          python -m venv .venv
+          source ./.venv/bin/activate
+          python -m pip install --upgrade pip
+          make install-dev
+
+      - name: Run unit tests
+        run: |
+          source ./.venv/bin/activate
+          python -m pytest --ignore=tests/integration
+
+  integration:
+    name: integration
+    needs: unit
+    if: ${{ !cancelled() && (needs.unit.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.force == true)) }}
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
+    concurrency:
+      group: integration-${{ inputs.environment || 'snowflake-aws-enterprise' }}
+      cancel-in-progress: false
+    outputs:
+      started: ${{ steps.mark.outputs.started }}
+      decision: ${{ steps.decide.outputs.decision }}
+    steps:
+      # Runs only after reviewer approval; its absence in outputs means the
+      # run was rejected (dismissed) and report must not block the PR.
+      - name: Mark run as approved
+        id: mark
+        run: echo "started=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: >-
+            ${{ github.event_name == 'pull_request_target'
+                && format('refs/pull/{0}/merge', github.event.pull_request.number)
+                || (inputs.pr_number != '' && format('refs/pull/{0}/merge', inputs.pr_number) || github.ref) }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: setup.py
 
       - name: Install dependencies
         run: |
@@ -116,26 +211,70 @@ jobs:
         run: |
           echo "pytest outcome: ${{ steps.tests.outcome }}"
           if [ "${{ steps.tests.outcome }}" != "success" ]; then
-            echo "::error::Integration tests failed — see 'Run integration tests' step. Merge will be blocked by the verdict job."
+            echo "::error::Integration tests failed — see 'Run integration tests' step. Merge will be blocked by the report job."
           fi
 
-  verdict:
-    name: integration verdict
-    needs: integration
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Decide merge gate
+      - name: Decide job outcome
+        id: decide
+        if: always()
         run: |
-          started='${{ needs.integration.outputs.started }}'
-          tests='${{ needs.integration.outputs.tests }}'
-          if [ "$started" != "true" ]; then
-            echo "::notice::Integration run was dismissed by a reviewer — not blocking merge."
+          if [ "${{ steps.tests.outcome }}" = "success" ]; then
+            echo "decision=pass" >> "$GITHUB_OUTPUT"
+          else
+            echo "decision=fail" >> "$GITHUB_OUTPUT"
+          fi
+
+  report:
+    name: report
+    needs: [unit, integration]
+    if: ${{ always() && (github.event_name == 'pull_request_target' || (github.event_name == 'workflow_dispatch' && inputs.pr_number != '')) }}
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    concurrency:
+      group: integration-status-${{ github.event.pull_request.head.sha || github.run_id }}
+      cancel-in-progress: false
+    steps:
+      - name: Post integration result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.unit.outputs.head_sha }}
+          RESULT: ${{ needs.integration.result }}
+          STARTED: ${{ needs.integration.outputs.started }}
+          DECISION: ${{ needs.integration.outputs.decision }}
+          ENVIRONMENT: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
+        run: |
+          if [ -z "$HEAD_SHA" ]; then
+            echo "::notice::no head sha resolved; nothing to report"
             exit 0
           fi
-          if [ "$tests" = "success" ]; then
-            echo "Integration tests passed."
+
+          target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          if [ "$RESULT" = "skipped" ] || [ "$RESULT" = "cancelled" ]; then
+            echo "::notice::integration job $RESULT; leaving status pending"
             exit 0
           fi
-          echo "::error::Integration tests ran and failed — blocking merge."
-          exit 1
+
+          if [ "$STARTED" != "true" ]; then
+            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
+              -f state=success \
+              -f context=integration \
+              -f description="Integration tests skipped by maintainer decision" \
+              -f target_url="$target_url"
+            exit 0
+          fi
+
+          if [ "$DECISION" = "pass" ]; then
+            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
+              -f state=success \
+              -f context=integration \
+              -f description="Integration tests passed on $ENVIRONMENT" \
+              -f target_url="$target_url"
+          else
+            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
+              -f state=failure \
+              -f context=integration \
+              -f description="Integration tests failed on $ENVIRONMENT — push a new commit for a fresh decision" \
+              -f target_url="$target_url"
+          fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,11 +16,16 @@ name: Integration Tests
 #               failure is already recorded for this commit (sticky) or an
 #               integration run is actively executing (defers to `report`).
 #
-# `report` (not `integration`) posts the final status: it distinguishes
-# "unit failed / run cancelled" (nothing posted, status stays pending) from
-# "reviewer rejected the deployment" (started output empty -> success) from
-# "tests ran" (decision output from a final always() step, based on the
-# continue-on-error pytest outcome).
+# `report` (not `integration`) posts the final status, based only on
+# needs.integration.result — computed by GitHub from step conclusions, and
+# not writable by untrusted PR code the way a self-reported job output
+# would be — and the `started` output: "unit failed / run cancelled"
+# (nothing posted, status stays pending) vs. "reviewer rejected the
+# deployment" (started output empty -> success) vs. "tests ran" (result ==
+# success -> success, else -> failure). Before posting, `report` re-reads
+# the combined status and refuses to overwrite an already-recorded failure
+# — the same sticky-failure rule pending/waive enforce — so re-running the
+# `integration` job alone can never clear a recorded failure.
 #
 # NOTE: use Reject to dismiss a run, not Cancel — a cancelled run is
 # excluded from `report`'s logic, so the status stays pending until re-run.
@@ -91,8 +96,9 @@ jobs:
       - name: Post pending status (fail closed)
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          count=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.pull_request.head.sha }}/status" \
+          count=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" \
             --jq '[.statuses[] | select(.context == "integration")] | length') || {
             echo "::notice::could not read existing integration status; not posting pending (fail closed)"
             exit 0
@@ -101,7 +107,7 @@ jobs:
             echo "::notice::integration status already recorded for this commit; not resetting"
             exit 0
           fi
-          gh api "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
             -f state=pending \
             -f context=integration \
             -f description="Waiting for a maintainer decision (run, skip, or approve the PR)" \
@@ -110,6 +116,9 @@ jobs:
   unit:
     name: unit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       head_sha: ${{ steps.sha.outputs.head_sha }}
     steps:
@@ -160,12 +169,12 @@ jobs:
     if: ${{ !cancelled() && (needs.unit.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.force == true)) }}
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
+    timeout-minutes: 45
     concurrency:
       group: integration-${{ inputs.environment || 'snowflake-aws-enterprise' }}
       cancel-in-progress: false
     outputs:
       started: ${{ steps.mark.outputs.started }}
-      decision: ${{ steps.decide.outputs.decision }}
     steps:
       # Runs only after reviewer approval; its absence in outputs means the
       # run was rejected (dismissed) and report must not block the PR.
@@ -193,7 +202,6 @@ jobs:
 
       - name: Run integration tests
         id: tests
-        continue-on-error: true
         run: python -m pytest tests/ --snowflake -m standard ${{ inputs.pytest_args }}
         env:
           TEST_SNOWFLAKE_ACCOUNT: ${{ secrets.TEST_SNOWFLAKE_ACCOUNT }}
@@ -207,23 +215,6 @@ jobs:
           VAR_STATIC_USER_RSA_PUBLIC_KEY: ${{ secrets.STATIC_USER_RSA_PUBLIC_KEY }}
           VAR_STATIC_USER_MFA_PASSWORD: ${{ secrets.STATIC_USER_MFA_PASSWORD }}
 
-      - name: Report test outcome
-        run: |
-          echo "pytest outcome: ${{ steps.tests.outcome }}"
-          if [ "${{ steps.tests.outcome }}" != "success" ]; then
-            echo "::error::Integration tests failed — see 'Run integration tests' step. Merge will be blocked by the report job."
-          fi
-
-      - name: Decide job outcome
-        id: decide
-        if: always()
-        run: |
-          if [ "${{ steps.tests.outcome }}" = "success" ]; then
-            echo "decision=pass" >> "$GITHUB_OUTPUT"
-          else
-            echo "decision=fail" >> "$GITHUB_OUTPUT"
-          fi
-
   report:
     name: report
     needs: [unit, integration]
@@ -232,7 +223,7 @@ jobs:
     permissions:
       statuses: write
     concurrency:
-      group: integration-status-${{ github.event.pull_request.head.sha || github.run_id }}
+      group: integration-status-${{ needs.unit.outputs.head_sha || github.run_id }}
       cancel-in-progress: false
     steps:
       - name: Post integration result
@@ -241,7 +232,6 @@ jobs:
           HEAD_SHA: ${{ needs.unit.outputs.head_sha }}
           RESULT: ${{ needs.integration.result }}
           STARTED: ${{ needs.integration.outputs.started }}
-          DECISION: ${{ needs.integration.outputs.decision }}
           ENVIRONMENT: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
         run: |
           if [ -z "$HEAD_SHA" ]; then
@@ -251,30 +241,40 @@ jobs:
 
           target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+          # Sticky failure: a recorded failure/error stands until a new
+          # commit; a status read that fails outright must also block
+          # (fail closed) so an API blip can never clobber an unread
+          # failure — the same guard pending/waive enforce, needed here so
+          # an ordinary "re-run jobs" can't silently clear a recorded
+          # failure with a fresh (possibly flaky-passing) result.
+          prior_state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" \
+            --jq '[.statuses[] | select(.context == "integration")][0].state') || {
+            echo "::notice::could not verify existing integration status; not posting"
+            exit 0
+          }
+          if [ "$prior_state" = "failure" ] || [ "$prior_state" = "error" ]; then
+            echo "::notice::recorded integration failure stands; only a new commit clears it"
+            exit 0
+          fi
+
           if [ "$RESULT" = "skipped" ] || [ "$RESULT" = "cancelled" ]; then
             echo "::notice::integration job $RESULT; leaving status pending"
             exit 0
           fi
 
           if [ "$STARTED" != "true" ]; then
-            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-              -f state=success \
-              -f context=integration \
-              -f description="Integration tests skipped by maintainer decision" \
-              -f target_url="$target_url"
-            exit 0
+            state=success
+            description="Integration tests skipped by maintainer decision"
+          elif [ "$RESULT" = "success" ]; then
+            state=success
+            description="Integration tests passed on $ENVIRONMENT"
+          else
+            state=failure
+            description="Integration tests failed on $ENVIRONMENT — push a new commit for a fresh decision"
           fi
 
-          if [ "$DECISION" = "pass" ]; then
-            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-              -f state=success \
-              -f context=integration \
-              -f description="Integration tests passed on $ENVIRONMENT" \
-              -f target_url="$target_url"
-          else
-            gh api "repos/${{ github.repository }}/statuses/$HEAD_SHA" \
-              -f state=failure \
-              -f context=integration \
-              -f description="Integration tests failed on $ENVIRONMENT — push a new commit for a fresh decision" \
-              -f target_url="$target_url"
-          fi
+          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context=integration \
+            -f description="$description" \
+            -f target_url="$target_url"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,122 @@
+name: Integration Tests
+
+# Owner-gated integration tests against a real Snowflake test account.
+#
+# Flow (requires "required reviewers" on the snowflake-* environments):
+#   - Every code PR queues an `integration` job that WAITS for an environment
+#     reviewer decision.
+#   - Approve  -> tests run. If they fail, the `verdict` job fails and blocks merge.
+#   - Reject   -> dismissed. The `verdict` job passes and the PR can merge.
+#   - No decision -> `verdict` stays pending and the PR cannot merge.
+#
+# `verdict` (not `integration`) is the job to mark as a required status check:
+# it distinguishes "reviewer dismissed the run" (job rejected before any step
+# ran -> outputs empty -> pass) from "tests ran and failed" (test step outcome
+# captured via continue-on-error -> fail).
+#
+# NOTE: use Reject to dismiss, not Cancel — a cancelled run leaves `verdict`
+# incomplete, which keeps the PR blocked until the workflow is re-run.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "snowcap/**"
+      - "tests/**"
+      - "conftest.py"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/integration-tests.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Snowflake test account
+        type: choice
+        default: snowflake-aws-enterprise
+        options:
+          - snowflake-aws-standard
+          - snowflake-aws-enterprise
+          - snowflake-aws-business-critical
+          - snowflake-azure-standard
+          - snowflake-gcp-standard
+      pytest_args:
+        description: Extra pytest args (e.g. -k warehouse)
+        required: false
+        default: ""
+
+# One run per test account at a time. A run waiting for reviewer decision can
+# hold the queue; dismiss (Reject) stale runs to release it.
+concurrency:
+  group: integration-${{ inputs.environment || 'snowflake-aws-enterprise' }}
+  cancel-in-progress: false
+
+jobs:
+  integration:
+    name: integration
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'snowflake-aws-enterprise' }}
+    outputs:
+      started: ${{ steps.mark.outputs.started }}
+      tests: ${{ steps.tests.outcome }}
+    steps:
+      # Runs only after reviewer approval; its absence in outputs means the
+      # run was rejected (dismissed) and verdict must not block the PR.
+      - name: Mark run as approved
+        id: mark
+        run: echo "started=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run integration tests
+        id: tests
+        continue-on-error: true
+        run: python -m pytest tests/ --snowflake -m standard ${{ inputs.pytest_args }}
+        env:
+          TEST_SNOWFLAKE_ACCOUNT: ${{ secrets.TEST_SNOWFLAKE_ACCOUNT }}
+          TEST_SNOWFLAKE_USER: ${{ secrets.TEST_SNOWFLAKE_USER }}
+          TEST_SNOWFLAKE_PASSWORD: ${{ secrets.TEST_SNOWFLAKE_PASSWORD }}
+          TEST_SNOWFLAKE_ROLE: ACCOUNTADMIN
+          TEST_SNOWFLAKE_WAREHOUSE: STATIC_WAREHOUSE
+          VAR_STORAGE_BASE_URL: ${{ secrets.VAR_STORAGE_BASE_URL }}
+          VAR_STORAGE_ROLE_ARN: ${{ secrets.VAR_STORAGE_ROLE_ARN }}
+          VAR_STORAGE_AWS_EXTERNAL_ID: ${{ secrets.VAR_STORAGE_AWS_EXTERNAL_ID }}
+          VAR_STATIC_USER_RSA_PUBLIC_KEY: ${{ secrets.STATIC_USER_RSA_PUBLIC_KEY }}
+          VAR_STATIC_USER_MFA_PASSWORD: ${{ secrets.STATIC_USER_MFA_PASSWORD }}
+
+      - name: Report test outcome
+        run: |
+          echo "pytest outcome: ${{ steps.tests.outcome }}"
+          if [ "${{ steps.tests.outcome }}" != "success" ]; then
+            echo "::error::Integration tests failed — see 'Run integration tests' step. Merge will be blocked by the verdict job."
+          fi
+
+  verdict:
+    name: integration verdict
+    needs: integration
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Decide merge gate
+        run: |
+          started='${{ needs.integration.outputs.started }}'
+          tests='${{ needs.integration.outputs.tests }}'
+          if [ "$started" != "true" ]; then
+            echo "::notice::Integration run was dismissed by a reviewer — not blocking merge."
+            exit 0
+          fi
+          if [ "$tests" = "success" ]; then
+            echo "Integration tests passed."
+            exit 0
+          fi
+          echo "::error::Integration tests ran and failed — blocking merge."
+          exit 1

--- a/.github/workflows/integration-waiver.yml
+++ b/.github/workflows/integration-waiver.yml
@@ -1,0 +1,101 @@
+name: Integration Waiver
+
+# Waives the `integration` commit status when a maintainer approves the PR
+# review, resolving the merge gate without requiring a Run/Skip decision on
+# integration-tests.yml. pull_request_review runs privileged in the
+# base-repo context even for fork PRs, so this workflow NEVER checks out
+# any code.
+#
+# Sticky failure: a recorded failure/error `integration` status for this
+# commit is never overwritten by a waive — only a fresh commit (and a fresh
+# maintainer decision) clears it. The combined-status read that enforces
+# this must fail closed: any API error reading it also blocks the waive,
+# since a blind write on an unreadable state could clobber an unread
+# failure.
+#
+# Four fail-closed exit paths, checked in order:
+#   1. AUTHORIZATION — reviewer's repo role_name must be admin or maintain.
+#   2. STICKY FAILURE — an existing failure/error `integration` status for
+#      this commit stands; a failed status read also blocks (fail closed).
+#   3. RUN IN FLIGHT — an integration job actively executing for this sha
+#      defers to `report` (integration-tests.yml), which posts the
+#      authoritative result when the run completes. A run merely waiting on
+#      environment approval does not count — that's the state waiving
+#      exists to resolve.
+#   4. WAIVE — post success with context `integration`.
+#
+# NOTE: dismissing a PR review approval does NOT revoke an already-posted
+# waiver; a new commit is required to reset the gate to pending.
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  waive:
+    name: waive
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+    concurrency:
+      group: integration-status-${{ github.event.pull_request.head.sha }}
+      cancel-in-progress: false
+    steps:
+      - name: Waive integration status (fail closed)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REVIEWER: ${{ github.event.review.user.login }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          # 1. AUTHORIZATION — role_name (not the legacy `permission` field,
+          # which maps maintain -> write and would wrongly reject maintainers).
+          if ! role_name=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$REVIEWER/permission" --jq .role_name); then
+            echo "::notice::could not determine $REVIEWER's repo role; not waiving"
+            exit 0
+          fi
+          if [ "$role_name" != "admin" ] && [ "$role_name" != "maintain" ]; then
+            echo "::notice::$REVIEWER's role ($role_name) does not authorize a waiver"
+            exit 0
+          fi
+
+          # 2. STICKY FAILURE — a recorded failure/error stands; any failure
+          # to read the combined status must also block (fail closed) so an
+          # API blip can never let a waive clobber an unread failure.
+          if ! state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" --jq '[.statuses[] | select(.context == "integration")][0].state'); then
+            echo "::notice::could not verify existing integration status; not waiving"
+            exit 0
+          fi
+          if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
+            echo "::notice::recorded integration failure stands; not waiving"
+            exit 0
+          fi
+
+          # 3. RUN IN FLIGHT — defer to `report` if an integration job is
+          # actually executing. Runs only 'waiting' on environment approval
+          # do not block — that's the normal state a waive resolves.
+          if ! run_ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/integration-tests.yml/runs?head_sha=$HEAD_SHA&status=in_progress" --jq '.workflow_runs[].id'); then
+            echo "::notice::could not check for an in-flight integration run; not waiving"
+            exit 0
+          fi
+          for run_id in $run_ids; do
+            if ! job_statuses=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs" --jq '.jobs[] | select(.name | startswith("integration")) | .status'); then
+              echo "::notice::could not read jobs for run $run_id; not waiving"
+              exit 0
+            fi
+            if echo "$job_statuses" | grep -q '^in_progress$'; then
+              echo "::notice::integration run executing; deferring to its result"
+              exit 0
+            fi
+          done
+
+          # 4. WAIVE
+          gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
+            -f state=success \
+            -f context=integration \
+            -f description="Integration tests waived by @$REVIEWER's approval" \
+            -f target_url="$PR_URL"

--- a/.github/workflows/integration-waiver.yml
+++ b/.github/workflows/integration-waiver.yml
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       statuses: write
+      actions: read
     concurrency:
       group: integration-status-${{ github.event.pull_request.head.sha }}
       cancel-in-progress: false
@@ -52,44 +53,34 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
+          bail() { echo "::notice::$1"; exit 0; }
+
           # 1. AUTHORIZATION — role_name (not the legacy `permission` field,
           # which maps maintain -> write and would wrongly reject maintainers).
-          if ! role_name=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$REVIEWER/permission" --jq .role_name); then
-            echo "::notice::could not determine $REVIEWER's repo role; not waiving"
-            exit 0
-          fi
-          if [ "$role_name" != "admin" ] && [ "$role_name" != "maintain" ]; then
-            echo "::notice::$REVIEWER's role ($role_name) does not authorize a waiver"
-            exit 0
-          fi
+          role_name=$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$REVIEWER/permission" --jq .role_name) ||
+            bail "could not determine $REVIEWER's repo role; not waiving"
+          [ "$role_name" = "admin" ] || [ "$role_name" = "maintain" ] ||
+            bail "$REVIEWER's role ($role_name) does not authorize a waiver"
 
           # 2. STICKY FAILURE — a recorded failure/error stands; any failure
           # to read the combined status must also block (fail closed) so an
           # API blip can never let a waive clobber an unread failure.
-          if ! state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" --jq '[.statuses[] | select(.context == "integration")][0].state'); then
-            echo "::notice::could not verify existing integration status; not waiving"
-            exit 0
-          fi
+          state=$(gh api "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" --jq '[.statuses[] | select(.context == "integration")][0].state') ||
+            bail "could not verify existing integration status; not waiving"
           if [ "$state" = "failure" ] || [ "$state" = "error" ]; then
-            echo "::notice::recorded integration failure stands; not waiving"
-            exit 0
+            bail "recorded integration failure stands; not waiving"
           fi
 
           # 3. RUN IN FLIGHT — defer to `report` if an integration job is
           # actually executing. Runs only 'waiting' on environment approval
           # do not block — that's the normal state a waive resolves.
-          if ! run_ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/integration-tests.yml/runs?head_sha=$HEAD_SHA&status=in_progress" --jq '.workflow_runs[].id'); then
-            echo "::notice::could not check for an in-flight integration run; not waiving"
-            exit 0
-          fi
+          run_ids=$(gh api "repos/$GITHUB_REPOSITORY/actions/workflows/integration-tests.yml/runs?head_sha=$HEAD_SHA&status=in_progress" --jq '.workflow_runs[].id') ||
+            bail "could not check for an in-flight integration run; not waiving"
           for run_id in $run_ids; do
-            if ! job_statuses=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs" --jq '.jobs[] | select(.name | startswith("integration")) | .status'); then
-              echo "::notice::could not read jobs for run $run_id; not waiving"
-              exit 0
-            fi
+            job_statuses=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/jobs" --jq '.jobs[] | select(.name | startswith("integration")) | .status') ||
+              bail "could not read jobs for run $run_id; not waiving"
             if echo "$job_statuses" | grep -q '^in_progress$'; then
-              echo "::notice::integration run executing; deferring to its result"
-              exit 0
+              bail "integration run executing; deferring to its result"
             fi
           done
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,6 +59,35 @@ pytest tests/integration/ --snowflake -v
 pytest tests/ --snowflake -v -m "not slow"
 ```
 
+## Continuous Integration
+
+Two tiers of CI run on pull requests:
+
+1. **Unit tests** (`run-tests.yml`) run automatically on every PR open and push.
+   A failure blocks merging (enforced via branch protection required checks:
+   `build (3.10)`, `build (3.11)`, `build (3.12)`).
+2. **Integration tests** (`integration-tests.yml`) queue automatically on code
+   PRs but wait for a repository owner's decision (GitHub environment
+   *required reviewers* on the `snowflake-*` environments):
+   - **Approve** — tests run against the selected Snowflake test account.
+     If they fail, the `integration verdict` required check fails and blocks merge.
+   - **Reject** — the run is dismissed. `integration verdict` passes and the
+     PR can merge without integration testing.
+   - Until an owner decides, `integration verdict` stays pending and the PR
+     cannot merge. Use **Reject** to dismiss — cancelling the run leaves the
+     check incomplete and keeps the PR blocked.
+
+Maintainers can also run integration tests against any of the five test
+accounts on demand via `workflow_dispatch`:
+
+```bash
+gh workflow run integration-tests.yml -f environment=snowflake-aws-enterprise -f pytest_args="-k warehouse"
+```
+
+Note: PRs from forks cannot access environment secrets on `pull_request`
+events; an approved run from a fork will fail to connect. Maintainers should
+push the fork branch to this repository to integration-test it.
+
 ## Environment Configuration
 
 ### Required Variables

--- a/TESTING.md
+++ b/TESTING.md
@@ -61,35 +61,63 @@ pytest tests/ --snowflake -v -m "not slow"
 
 ## Continuous Integration
 
-Two tiers of CI run on pull requests:
+Two independent merge gates run on pull requests: unit tests (a required
+check) and integration tests (a required commit status).
 
-1. **Unit tests** (`run-tests.yml`) run automatically on every PR open and push.
-   A failure blocks merging (enforced via branch protection required checks:
-   `build (3.10)`, `build (3.11)`, `build (3.12)`).
-2. **Integration tests** (`integration-tests.yml`) queue automatically on code
-   PRs but wait for a repository owner's decision (GitHub environment
-   *required reviewers* on the `snowflake-*` environments):
-   - **Approve** — tests run against the selected Snowflake test account.
-     If they fail, the `integration verdict` required check fails and blocks merge.
-   - **Reject** — the run is dismissed. `integration verdict` passes and the
-     PR can merge without integration testing.
-   - Until an owner decides, `integration verdict` stays pending and the PR
-     cannot merge. Use **Reject** to dismiss — cancelling the run leaves the
-     check incomplete and keeps the PR blocked.
+### Unit tests
 
-Maintainers can also run integration tests against any of the five test
-accounts on demand via `workflow_dispatch`:
+`run-tests.yml` runs on every PR open and push. A failure blocks merge via
+branch protection's required checks: `build (3.10)`, `build (3.11)`,
+`build (3.12)`.
+
+### Integration tests
+
+`integration-tests.yml` posts a commit status named `integration`, which is
+also a required check on `main`. On PR open and push, the `pending` job
+posts state `pending` for PRs that touch code paths (see the workflow's
+`paths:` filter); docs-only PRs get no pending status, but branch protection
+still shows `integration` as "Expected" and blocks merge until one of the
+decisions below resolves it.
+
+The PR cannot merge until a maintainer makes one of three decisions:
+
+| Decision | How | `integration` status | Notes |
+|----------|-----|-----------------------|-------|
+| Run | Approve the environment deployment (the GitHub required-reviewer prompt on the `snowflake-*` environment) | `success` if tests pass, `failure` if they fail | A failure blocks merge even after the PR is later approved — only a new commit (with a fresh `pending`) clears it. |
+| Skip | Reject the pending deployment | `success` ("skipped by maintainer decision") | |
+| Waive | A reviewer with the `maintain` or `admin` repo role approves the PR | `success` ("waived"), posted by `integration-waiver.yml` | Never overwrites a recorded failure. If an integration run is actively executing for the commit, the waiver defers and the run's own result stands instead. |
+
+Integration only becomes available once the in-workflow `unit` job passes on
+the latest commit (`needs: unit`). Maintainers can override this with
+`workflow_dispatch` and `force=true`, and can target any of the five
+`snowflake-*` environments:
 
 ```bash
 gh workflow run integration-tests.yml -f environment=snowflake-aws-enterprise \
-  -f pr_number=36 -f pytest_args="-k warehouse"
+  -f pr_number=36 -f pytest_args="-k warehouse" -f force=true
 ```
 
-Fork PRs are supported: the workflow uses `pull_request_target`, so it runs
-from the base repository (with access to environment secrets) and checks out
-the PR merge ref only inside the reviewer-approved job. Because approval is
-what authorizes untrusted code to run with test-account credentials,
-**reviewers must read the PR diff before approving**.
+### Contributor flow
+
+Open a PR from a fork. No Snowflake account or credentials are needed:
+`pull_request_target` runs the workflow from the base repository, and
+`secrets.*` is read only inside the reviewer-approved `integration` job.
+Wait for a maintainer to make one of the three decisions above.
+
+### Maintainer guidance
+
+- Read the diff before approving the environment deployment — approval runs
+  untrusted PR code with test-account credentials.
+- Use **Reject**, not **Cancel**, to dismiss a run: cancelling leaves the
+  status `pending` instead of resolving it.
+- A new push resets the status to `pending` and requires a fresh decision.
+- Re-running jobs never resets a recorded decision — the `pending` job skips
+  commits that already have an `integration` status.
+
+### Known limitation
+
+Dismissing a PR review approval does not revoke an already-posted waiver.
+Push a new commit to reset the gate.
 
 ## Environment Configuration
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -81,12 +81,15 @@ Maintainers can also run integration tests against any of the five test
 accounts on demand via `workflow_dispatch`:
 
 ```bash
-gh workflow run integration-tests.yml -f environment=snowflake-aws-enterprise -f pytest_args="-k warehouse"
+gh workflow run integration-tests.yml -f environment=snowflake-aws-enterprise \
+  -f pr_number=36 -f pytest_args="-k warehouse"
 ```
 
-Note: PRs from forks cannot access environment secrets on `pull_request`
-events; an approved run from a fork will fail to connect. Maintainers should
-push the fork branch to this repository to integration-test it.
+Fork PRs are supported: the workflow uses `pull_request_target`, so it runs
+from the base repository (with access to environment secrets) and checks out
+the PR merge ref only inside the reviewer-approved job. Because approval is
+what authorizes untrusted code to run with test-account credentials,
+**reviewers must read the PR diff before approving**.
 
 ## Environment Configuration
 


### PR DESCRIPTION
Contributors can't integration-test their PRs — the suite needs a real Snowflake account, and auto-running it would spend project money and expose credentials to untrusted code. This PR lets any PR (including forks) run the integration suite on the project's test accounts, but only after a maintainer decides.

## How it works

Every code PR gets a required commit status named `integration`, posted as `pending`. It resolves when a maintainer does one of three things:

| Decision | How | Result |
|----------|-----|--------|
| Run the tests | Approve the environment deployment | `success` if they pass; `failure` if not — only a new commit clears a failure |
| Skip the tests | Reject the deployment | `success` |
| Approve the PR | Normal review approval (maintain/admin) | `success` (waived) — never overrides a failure |

Unit tests must pass before the integration job can be approved (`needs: unit`); maintainers can bypass that with `workflow_dispatch` + `force=true`.

## Files

- `integration-tests.yml` — runs the suite and posts the status
- `integration-waiver.yml` — posts the waiver on review approval
- `TESTING.md` — the flow, documented for contributors and maintainers

## Security 
Untrusted PR code only ever runs with a read-only token and no secrets; secrets exist only in the maintainer-approved job; status-posting jobs never check out code.

## Setup after merge

- [ ] Required reviewers + "prevent self-review" on the five `snowflake-*` environments
- [ ] Required status checks on `main`: `build (3.10)`, `build (3.11)`, `build (3.12)`, `integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184vjCYof55QxMRkrSJZgDk
