### PR TITLE
Explain missing system roles instead of suggesting a rename

### DIFF
--- a/docs/snowflake-permissions.md
+++ b/docs/snowflake-permissions.md
@@ -98,6 +98,51 @@ If your configuration includes any of these, you have two options:
 
 Most teams choose Option B as they mature their setup.
 
+## System roles and ORGADMIN
+
+Snowflake's built-in roles (ACCOUNTADMIN, SECURITYADMIN, USERADMIN, SYSADMIN, PUBLIC, ORGADMIN) are never created by Snowcap. You can reference them and grant them, but they have to already exist in the account.
+
+That last part matters for **ORGADMIN**, which is the one system role Snowflake does not enable everywhere. It is enabled in an organization's *primary* account only. In any other account the role simply does not exist, so a config that grants it fails at plan time:
+
+```yaml
+role_grants:
+  - to_user: someuser
+    roles:
+      - ORGADMIN   # fails unless ORGADMIN is enabled in this account
+```
+
+```
+Role "ORGADMIN" not found.
+  Referenced by: role grant to user "SOMEUSER"
+  Note: ORGADMIN is only enabled in an organization's primary account. Snowcap
+  cannot enable it for you, because it does not manage accounts. Enable it manually
+  by running `ALTER ACCOUNT <this_account> SET IS_ORG_ADMIN = TRUE` as ORGADMIN,
+  from the primary account (or any account where ORGADMIN is already enabled), then
+  re-run. Otherwise remove the reference.
+```
+
+### Enabling ORGADMIN in another account
+
+This has to be done from an account that already holds the role, and it is not something Snowcap manages (see below):
+
+```sql
+USE ROLE ORGADMIN;
+ALTER ACCOUNT my_account SET IS_ORG_ADMIN = TRUE;
+```
+
+Two constraints worth knowing:
+
+- `ALTER ACCOUNT` here accepts only the **account name** form of the identifier, not the account locator.
+- ORGADMIN can be enabled in at most **eight accounts** per organization by default. Contact Snowflake Support if you need more.
+
+Once the role exists in the account, granting it is an ordinary role grant and Snowcap handles it like any other.
+
+### Known limitation: Snowcap cannot enable ORGADMIN
+
+Snowcap has no resource for the `IS_ORG_ADMIN` account property. [AccountParameter](resources/account_parameter.md) is not a substitute: it emits `ALTER ACCOUNT SET <parameter> = <value>` against the account in the current session, while enabling ORGADMIN requires `ALTER ACCOUNT <name> SET IS_ORG_ADMIN = TRUE` — a different statement, targeting a *named* account, run from a *different* account.
+
+Enable it out of band with the SQL above, then manage the grants declaratively.
+
 ## What ACCOUNTADMIN can do that SNOWCAP_ADMIN cannot
 
 This is the full list of ACCOUNTADMIN-exclusive capabilities that have nothing to do with Snowcap. It's useful context when explaining the custom role to a security team.

--- a/docs/snowflake-permissions.md
+++ b/docs/snowflake-permissions.md
@@ -139,7 +139,7 @@ Once the role exists in the account, granting it is an ordinary role grant and S
 
 ### Known limitation: Snowcap cannot enable ORGADMIN
 
-Snowcap has no resource for the `IS_ORG_ADMIN` account property. [AccountParameter](resources/account_parameter.md) is not a substitute: it emits `ALTER ACCOUNT SET <parameter> = <value>` against the account in the current session, while enabling ORGADMIN requires `ALTER ACCOUNT <name> SET IS_ORG_ADMIN = TRUE` — a different statement, targeting a *named* account, run from a *different* account.
+Snowcap has no resource for the `IS_ORG_ADMIN` account property. [AccountParameter](resources/account_parameter.md) is not a substitute: it emits `ALTER ACCOUNT SET <parameter> = <value>` against the account in the current session, while enabling ORGADMIN requires `ALTER ACCOUNT <name> SET IS_ORG_ADMIN = TRUE`, a different statement targeting a *named* account, run from a *different* account.
 
 Enable it out of band with the SQL above, then manage the grants declaratively.
 

--- a/snowcap/error_formatting.py
+++ b/snowcap/error_formatting.py
@@ -5,7 +5,46 @@ User-friendly error message formatting for Snowcap exceptions.
 import difflib
 from typing import Optional
 
+from .builtins import SYSTEM_ROLES
 from .identifiers import URN
+
+# System roles that Snowflake does not enable in every account. Referencing one
+# of these fails with the same "not found" error as a typo, even though the
+# cause and the fix are entirely different, so we explain them specifically.
+_CONDITIONAL_SYSTEM_ROLE_HINTS = {
+    "ORGADMIN": (
+        "ORGADMIN is only enabled in an organization's primary account. Snowcap cannot "
+        "enable it for you, because it does not manage accounts. Enable it manually by "
+        "running `ALTER ACCOUNT <this_account> SET IS_ORG_ADMIN = TRUE` as ORGADMIN, "
+        "from the primary account (or any account where ORGADMIN is already enabled), "
+        "then re-run. Otherwise remove the reference."
+    ),
+}
+
+_GENERIC_SYSTEM_ROLE_HINT = (
+    "{name} is a Snowflake system role, so this is unlikely to be a typo. It is either "
+    "not enabled in this account or not visible to the session role."
+)
+
+
+def _system_role_hint(urn: URN) -> Optional[str]:
+    """
+    Explain why a built-in system role might be missing.
+
+    System roles are never created by Snowcap, so the usual "did you mean" suggestion
+    is misleading for them: the reference is spelled correctly and the fix is to enable
+    the role or grant visibility, not to rename anything.
+
+    Returns None for ordinary roles and for every other resource type.
+    """
+    if urn.resource_label != "role":
+        return None
+
+    name = str(urn.fqn.name).strip('"').upper()
+    if name not in SYSTEM_ROLES:
+        return None
+
+    return _CONDITIONAL_SYSTEM_ROLE_HINTS.get(name, _GENERIC_SYSTEM_ROLE_HINT.format(name=name))
 
 
 def _get_resource_display_name(urn: URN) -> str:
@@ -60,6 +99,12 @@ def format_missing_resource_error(
     # Add context about what references it
     if required_by_urn:
         msg += f"\n  Referenced by: {_format_reference(required_by_urn)}"
+
+    # System roles are spelled correctly by definition, so explain the real cause
+    # instead of offering near-miss names the user did not mean.
+    system_role_hint = _system_role_hint(missing_urn)
+    if system_role_hint:
+        return msg + f"\n  Note: {system_role_hint}"
 
     # Add suggestions if available
     if available_names:
@@ -140,6 +185,10 @@ def format_missing_pointer_error(
     resource_name = _get_resource_display_name(urn)
 
     msg = f'{resource_type} "{resource_name}" not found.'
+
+    system_role_hint = _system_role_hint(urn)
+    if system_role_hint:
+        return msg + f"\n  Note: {system_role_hint}"
 
     # Add suggestions if available
     if available_names:

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -1,0 +1,85 @@
+"""
+Tests for user-facing error message formatting.
+
+These focus on the system-role case: Snowflake's built-in roles are never created
+by Snowcap, so a "not found" error for one of them means something different from
+a missing user-defined resource, and the message should say so.
+"""
+
+from snowcap.error_formatting import (
+    format_missing_pointer_error,
+    format_missing_resource_error,
+)
+from snowcap.identifiers import parse_URN
+
+
+def test_missing_orgadmin_explains_it_is_primary_account_only():
+    msg = format_missing_resource_error(
+        parse_URN("urn::ABCD123:role/ORGADMIN"),
+        parse_URN("urn::ABCD123:role_grant/ORGADMIN?user=SOMEUSER"),
+    )
+
+    assert 'Role "ORGADMIN" not found.' in msg
+    assert "primary account" in msg
+    assert "IS_ORG_ADMIN" in msg
+
+
+def test_missing_orgadmin_says_snowcap_cannot_fix_it_for_you():
+    """
+    The actionable part: Snowcap does not manage accounts, so waiting for it to
+    reconcile the role will never work. The user has to run ALTER ACCOUNT.
+    """
+    msg = format_missing_resource_error(parse_URN("urn::ABCD123:role/ORGADMIN"))
+
+    assert "Snowcap cannot enable it for you" in msg
+    assert "manually" in msg
+
+
+def test_missing_orgadmin_does_not_suggest_a_rename():
+    """ORGADMIN is spelled correctly; offering a near-miss name would mislead."""
+    msg = format_missing_resource_error(
+        parse_URN("urn::ABCD123:role/ORGADMIN"),
+        available_names=["ORGADMIN_BACKUP", "SYSADMIN"],
+    )
+
+    assert "Did you mean" not in msg
+
+
+def test_other_system_roles_get_a_generic_explanation():
+    msg = format_missing_resource_error(parse_URN("urn::ABCD123:role/SYSADMIN"))
+
+    assert "system role" in msg
+    assert "not visible to the session role" in msg
+    # The ORGADMIN-specific advice should not leak onto unrelated system roles.
+    assert "IS_ORG_ADMIN" not in msg
+
+
+def test_user_defined_roles_still_get_suggestions():
+    """The system-role branch must not swallow the existing behavior."""
+    msg = format_missing_resource_error(
+        parse_URN("urn::ABCD123:role/ANALYSTT"),
+        available_names=["ANALYST", "REPORTER"],
+    )
+
+    assert "Did you mean: ANALYST?" in msg
+    assert "system role" not in msg
+
+
+def test_non_role_resources_are_unaffected():
+    msg = format_missing_resource_error(
+        parse_URN("urn::ABCD123:warehouse/ORGADMIN"),
+        available_names=["WH_TRANSFORMING"],
+    )
+
+    assert "primary account" not in msg
+    assert "system role" not in msg
+
+
+def test_pointer_errors_explain_system_roles_too():
+    msg = format_missing_pointer_error(
+        parse_URN("urn::ABCD123:role/ORGADMIN"),
+        available_names=["ORGADMIN_BACKUP"],
+    )
+
+    assert "primary account" in msg
+    assert "Did you mean" not in msg


### PR DESCRIPTION
## Problem

Referencing a Snowflake system role that isn't present in the account fails with the same `not found` error as a typo, followed by a `Did you mean` suggestion. For a system role that guidance is actively wrong — the name is spelled correctly, Snowcap never creates these roles, and no rename will fix it.

**ORGADMIN is the case that actually bites.** It's enabled only in an organization's *primary* account, so a config that grants it plans fine in one account and fails in another:

```
Error fetching reference urn::DQB72262:role/ORGADMIN: Role "ORGADMIN" not found.
  Referenced by: role grant to user "SOMEUSER"
```

Nothing there hints that ORGADMIN is special, that Snowcap can't resolve it, or what to do. The natural assumption is that Snowcap should reconcile a role it obviously knows about — so you wait for a fix that will never come.

## Change

System roles now get an explanation instead of a suggestion:

```
Role "ORGADMIN" not found.
  Referenced by: role grant to user "SOMEUSER"
  Note: ORGADMIN is only enabled in an organization's primary account. Snowcap cannot
  enable it for you, because it does not manage accounts. Enable it manually by running
  `ALTER ACCOUNT <this_account> SET IS_ORG_ADMIN = TRUE` as ORGADMIN, from the primary
  account (or any account where ORGADMIN is already enabled), then re-run. Otherwise
  remove the reference.
```

Three things stated outright rather than left to inference: **Snowcap won't fix it**, **run it manually**, **from the primary account** (parenthesised, since ORGADMIN can be enabled in up to 8 accounts, so "the primary account" alone would be subtly wrong).

Other system roles get a shorter note pointing at enablement or session visibility. **User-defined roles keep the existing `Did you mean` behavior** — the new branch returns early only for names in `SYSTEM_ROLES`.

Applies to both `format_missing_resource_error` and `format_missing_pointer_error`.

## Docs

Adds a **System roles and ORGADMIN** section to `docs/snowflake-permissions.md`: how to enable it, the account-name-vs-locator constraint, the eight-account limit, and a *Known limitation* noting Snowcap can't enable it — including why `AccountParameter` isn't a workaround (it emits `ALTER ACCOUNT SET` against the *current* account, while enabling ORGADMIN targets a *named* account from a *different* one).

## Testing

New `tests/test_error_formatting.py` — 7 tests covering the ORGADMIN message, suppression of misleading rename suggestions, the generic system-role case, non-role resources, and the unchanged user-defined-role path.

- Full unit suite: **1571 passed**
- `mypy` clean
- No new `ruff` errors (`main` is already at 723 with an unpinned ruff; this doesn't add to the count in a way CI would newly flag)

## Not included

Groundwork for actually managing `IS_ORG_ADMIN` is pushed separately on `wip/account-is-org-admin` — it isn't mergeable because `Blueprint` rejects organization-scoped resources. Tracked in #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)