### PR TITLE
Make export usable on large accounts (10k SHOW cap, O(n^2) grant lookup, unqualified resources)

### DIFF
--- a/snowcap/cli.py
+++ b/snowcap/cli.py
@@ -24,7 +24,7 @@ from snowcap.operations.blueprint import (
     blueprint_plan,
 )
 from snowcap.operations.connector import connect, get_env_vars
-from snowcap.operations.export import export_resources
+from snowcap.operations.export import DEFAULT_EXPORT_THREADS, export_resources
 
 click.rich_click.ERRORS_SUGGESTION = "Try using the '--debug' flag for more information.\n"
 
@@ -358,7 +358,19 @@ def apply(
 )
 @click.option("--out", type=str, help="Write exported config to a file", metavar="<filename>")
 @click.option("--format", type=click.Choice(["json", "yml"]), default="yml", help="Output format")
-def export(resources, export_all, exclude_resources, out, format) -> None:
+@click.option(
+    "--threads",
+    type=int,
+    default=DEFAULT_EXPORT_THREADS,
+    help="Parallel fetches. Raise on large accounts; each resource costs a round trip",
+    metavar="<n>",
+)
+@click.option(
+    "--use-account-usage/--no-use-account-usage",
+    default=True,
+    help="Bulk-fetch grants from ACCOUNT_USAGE instead of per-role SHOW (much faster; lags live state)",
+)
+def export(resources, export_all, exclude_resources, out, format, threads, use_account_usage) -> None:
     """
     Generate a resource config for existing Snowflake resources
 
@@ -388,9 +400,13 @@ def export(resources, export_all, exclude_resources, out, format) -> None:
 
     resource_config: dict[str, Any] = {}
     if resources:
-        resource_config = export_resources(include=resources)
+        resource_config = export_resources(
+            include=resources, threads=threads, use_account_usage=use_account_usage
+        )
     elif export_all:
-        resource_config = export_resources(exclude=exclude_resources)
+        resource_config = export_resources(
+            exclude=exclude_resources, threads=threads, use_account_usage=use_account_usage
+        )
     else:
         raise
 

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -3,6 +3,7 @@ import inspect
 import json
 import logging
 import sys
+import threading
 from functools import cache
 from typing import Any, Optional, TypedDict, Union
 
@@ -173,6 +174,69 @@ def _fail_if_not_granted(result, *args):
         raise Exception(result[0]["status"], *args)
 
 
+# Lookup index over a single role's grants, keyed by
+# (session id, role, role type, grant type) -> {(granted_on, privilege, name key): grant}.
+#
+# Without it _fetch_grant_to_role scans the role's entire grant list and builds two
+# ResourceName objects per candidate. Exporting an account with ~91k grants therefore does
+# tens of millions of scans and hundreds of millions of ResourceName constructions -- pure
+# CPU, GIL-bound, so --threads cannot help. Indexing makes each lookup O(1).
+_GRANT_LOOKUP_INDEX_CACHE: dict[tuple, dict[tuple, dict[str, Any]]] = {}
+_GRANT_LOOKUP_INDEX_LOCK = threading.Lock()
+
+
+def _grant_name_key(name: str) -> str:
+    """
+    Canonical key for a grant target name, matching ResourceName equality semantics.
+
+    ResourceName.__hash__ is hash(str(self)), but str() keeps the quotes for quoted names
+    while __eq__ treats quoted "FOO" and unquoted FOO as equal -- so ResourceName is unsafe
+    as a dict key here. Normalising to "exact if quoted, upper-cased if not" reproduces
+    __eq__ exactly across all four quoted/unquoted combinations.
+    """
+    rendered = str(ResourceName(name))
+    return rendered[1:-1] if rendered.startswith('"') else rendered
+
+
+def _grant_lookup_index(
+    session: SnowflakeConnection,
+    grant_type: GrantType,
+    role: ResourceName,
+    role_type: ResourceType,
+) -> dict[tuple, dict[str, Any]]:
+    """Return (building if needed) the (granted_on, privilege, name) index for one role."""
+    cache_key = (id(session), str(role), role_type, grant_type)
+    index = _GRANT_LOOKUP_INDEX_CACHE.get(cache_key)
+    if index is not None:
+        return index
+
+    if grant_type == GrantType.FUTURE:
+        if role_type == ResourceType.DATABASE_ROLE:
+            grants = _show_future_grants_to_database_role(session, str(role), cacheable=True)
+        else:
+            grants = _show_future_grants_to_role(session, role, cacheable=True)
+    else:
+        grants = _show_grants_to_role(session, role, role_type=role_type, cacheable=True)
+
+    with _GRANT_LOOKUP_INDEX_LOCK:
+        index = _GRANT_LOOKUP_INDEX_CACHE.get(cache_key)
+        if index is None:
+            index = {}
+            for grant in grants:
+                is_account = grant["granted_on"] == "ACCOUNT"
+                name = "ACCOUNT" if is_account else grant["name"]
+                key = (
+                    grant["granted_on"],
+                    grant["privilege"],
+                    name if is_account else _grant_name_key(name),
+                )
+                # First match wins, preserving the original linear scan's behaviour when
+                # duplicate grants exist (e.g. granted by two different roles).
+                index.setdefault(key, grant)
+            _GRANT_LOOKUP_INDEX_CACHE[cache_key] = index
+    return index
+
+
 def _fetch_grant_to_role(
     session: SnowflakeConnection,
     grant_type: GrantType,
@@ -182,20 +246,9 @@ def _fetch_grant_to_role(
     privilege: str,
     role_type: ResourceType = ResourceType.ROLE,
 ):
-    if grant_type == GrantType.FUTURE:
-        if role_type == ResourceType.DATABASE_ROLE:
-            grants = _show_future_grants_to_database_role(session, str(role), cacheable=True)
-        else:
-            grants = _show_future_grants_to_role(session, role, cacheable=True)
-    else:
-        grants = _show_grants_to_role(session, role, role_type=role_type, cacheable=True)
-    for grant in grants:
-        name = "ACCOUNT" if grant["granted_on"] == "ACCOUNT" else grant["name"]
-        # Use ResourceName for comparison to handle quoted identifiers correctly
-        name_matches = ResourceName(name) == ResourceName(on_name) if name != "ACCOUNT" else name == on_name
-        if grant["granted_on"] == granted_on and grant["privilege"] == privilege and name_matches:
-            return grant
-    return None
+    index = _grant_lookup_index(session, grant_type, role, role_type)
+    name_key = on_name if granted_on == "ACCOUNT" else _grant_name_key(on_name)
+    return index.get((granted_on, privilege, name_key))
 
 
 def _filter_result(result, **kwargs):
@@ -588,13 +641,9 @@ def _show_grants_to_role(
     if role_type == ResourceType.ROLE:
         session_id = id(session)
         if session_id in _ACCOUNT_USAGE_GRANTS_CACHE:
-            # Filter cached grants by role name (case-insensitive)
-            role_upper = str(role).upper()
-            filtered_grants = [
-                grant
-                for grant in _ACCOUNT_USAGE_GRANTS_CACHE[session_id]
-                if grant["grantee_name"].upper() == role_upper and grant["granted_to"] == "ROLE"
-            ]
+            # O(1) lookup via the role index -- see _grants_by_role_index for why a plain
+            # scan here is not viable on large accounts.
+            filtered_grants = _grants_by_role_index(session_id).get(str(role).upper(), [])
             logger.debug(f"Using ACCOUNT_USAGE cache for grants to role {role} ({len(filtered_grants)} grants)")
             return filtered_grants
 
@@ -879,6 +928,32 @@ _ACCOUNT_USAGE_GRANTS_CACHE: dict[int, list[dict[str, Any]]] = {}
 # Stores the normalized grant list from GRANTS_TO_USERS
 _ACCOUNT_USAGE_USER_GRANTS_CACHE: dict[int, list[dict[str, Any]]] = {}
 
+# Role-name index over _ACCOUNT_USAGE_GRANTS_CACHE (keyed by session id, then upper-cased
+# grantee name). Without it, every grant lookup rescans the whole grant list: on an account
+# with ~30k grants, exporting grants is O(n^2) and spends minutes in pure Python with no
+# database activity at all. Built once per session, on first use.
+_ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE: dict[int, dict[str, list[dict[str, Any]]]] = {}
+_ACCOUNT_USAGE_GRANTS_INDEX_LOCK = threading.Lock()
+
+
+def _grants_by_role_index(session_id: int) -> dict[str, list[dict[str, Any]]]:
+    """Return (building if needed) the role -> grants index for a session's grant cache."""
+    index = _ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE.get(session_id)
+    if index is not None:
+        return index
+    with _ACCOUNT_USAGE_GRANTS_INDEX_LOCK:
+        # Re-check: another thread may have built it while we waited for the lock.
+        index = _ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE.get(session_id)
+        if index is None:
+            index = {}
+            for grant in _ACCOUNT_USAGE_GRANTS_CACHE.get(session_id, []):
+                if grant["granted_to"] != "ROLE":
+                    continue
+                index.setdefault(grant["grantee_name"].upper(), []).append(grant)
+            _ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE[session_id] = index
+            logger.debug(f"Built ACCOUNT_USAGE grant index: {len(index)} roles")
+    return index
+
 
 def reset_account_usage_caches() -> None:
     """
@@ -889,11 +964,16 @@ def reset_account_usage_caches() -> None:
     """
     global _ACCOUNT_USAGE_ACCESS_CACHE, _ACCOUNT_USAGE_FALLBACK_CACHE
     global _ACCOUNT_USAGE_GRANTS_CACHE, _ACCOUNT_USAGE_USER_GRANTS_CACHE
+    global _ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE, _GRANT_LOOKUP_INDEX_CACHE
 
     _ACCOUNT_USAGE_ACCESS_CACHE.clear()
     _ACCOUNT_USAGE_FALLBACK_CACHE.clear()
     _ACCOUNT_USAGE_GRANTS_CACHE.clear()
     _ACCOUNT_USAGE_USER_GRANTS_CACHE.clear()
+    # Derived from _ACCOUNT_USAGE_GRANTS_CACHE, so it must be invalidated alongside it --
+    # otherwise a stale index would outlive the data it was built from.
+    _ACCOUNT_USAGE_GRANTS_BY_ROLE_CACHE.clear()
+    _GRANT_LOOKUP_INDEX_CACHE.clear()
 
 
 def _mark_account_usage_fallback(session: SnowflakeConnection) -> None:
@@ -4019,7 +4099,69 @@ def list_shares(session: SnowflakeConnection) -> list[FQN]:
     return shares
 
 
+def _list_schema_scoped_from_account_usage(session: SnowflakeConnection, sql: str) -> Optional[list[FQN]]:
+    """
+    List schema-scoped objects from SNOWFLAKE.ACCOUNT_USAGE instead of SHOW ... IN ACCOUNT.
+
+    Snowflake caps SHOW output at 10,000 rows (error 090153), which makes SHOW ... IN ACCOUNT
+    unusable on large accounts -- listing simply fails and takes the whole export/plan with it.
+    ACCOUNT_USAGE has no such cap and answers in one query.
+
+    The query must alias its columns to the lowercase names SHOW uses ("database_name",
+    "schema_name", "name") so callers can share row-handling code.
+
+    Returns None when ACCOUNT_USAGE is unavailable or the query fails, so callers can fall
+    back to SHOW.
+
+    CAVEAT: ACCOUNT_USAGE lags live state (commonly up to ~2 hours, occasionally more), so
+    objects created very recently may be missing. SHOW is real-time. This is a deliberate
+    trade-off: on an account past the 10k cap, a slightly stale answer beats no answer.
+    """
+    if not _has_account_usage_access(session):
+        return None
+    try:
+        rows = execute(session, sql, cacheable=True)
+    except Exception as e:  # noqa: BLE001 - any failure should fall back to SHOW
+        logger.warning(f"ACCOUNT_USAGE listing failed, falling back to SHOW: {e}")
+        _mark_account_usage_fallback(session)
+        return None
+
+    user_databases = {str(db) for db in _list_databases(session)}
+    results = []
+    for row in rows:
+        database = row["database_name"]
+        if database in SYSTEM_DATABASES or database not in user_databases:
+            continue
+        if row["schema_name"] == "INFORMATION_SCHEMA":
+            continue
+        results.append(
+            FQN(
+                database=resource_name_from_snowflake_metadata(database),
+                schema=resource_name_from_snowflake_metadata(row["schema_name"]),
+                name=resource_name_from_snowflake_metadata(row["name"]),
+            )
+        )
+    return results
+
+
 def list_stages(session: SnowflakeConnection) -> list[FQN]:
+    # Named stages only. SHOW STAGES IN ACCOUNT also returns one implicit stage per table,
+    # so on this shape of account it returns thousands of rows to discard; ACCOUNT_USAGE.STAGES
+    # holds named stages only.
+    from_account_usage = _list_schema_scoped_from_account_usage(
+        session,
+        """
+        SELECT stage_catalog AS "database_name",
+               stage_schema  AS "schema_name",
+               stage_name    AS "name"
+        FROM SNOWFLAKE.ACCOUNT_USAGE.STAGES
+        WHERE deleted IS NULL
+          AND stage_type IN ('Internal Named', 'External Named')
+        """,
+    )
+    if from_account_usage is not None:
+        return from_account_usage
+
     show_result = execute(session, "SHOW STAGES IN ACCOUNT", cacheable=True)
     stages = []
     for row in show_result:
@@ -4046,6 +4188,25 @@ def list_streams(session: SnowflakeConnection) -> list[FQN]:
 
 
 def list_tables(session: SnowflakeConnection) -> list[FQN]:
+    # ACCOUNT_USAGE.TABLES covers every table type, so the exclusions below (external,
+    # hybrid, iceberg, dynamic, event) map onto table_type plus the is_* flags.
+    from_account_usage = _list_schema_scoped_from_account_usage(
+        session,
+        """
+        SELECT table_catalog AS "database_name",
+               table_schema  AS "schema_name",
+               table_name    AS "name"
+        FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES
+        WHERE deleted IS NULL
+          AND table_type = 'BASE TABLE'
+          AND COALESCE(is_iceberg, 'NO') = 'NO'
+          AND COALESCE(is_dynamic, 'NO') = 'NO'
+          AND COALESCE(is_hybrid,  'NO') = 'NO'
+        """,
+    )
+    if from_account_usage is not None:
+        return from_account_usage
+
     show_result = execute(session, "SHOW TABLES IN ACCOUNT", cacheable=True)
     user_databases = _list_databases(session)
     tables = []
@@ -4271,6 +4432,22 @@ def list_users(session: SnowflakeConnection) -> list[FQN]:
 
 
 def list_views(session: SnowflakeConnection) -> list[FQN]:
+    # Read from ACCOUNT_USAGE.TABLES rather than .VIEWS: table_type distinguishes plain
+    # views from materialized ones, which is the exclusion the SHOW path applies below.
+    from_account_usage = _list_schema_scoped_from_account_usage(
+        session,
+        """
+        SELECT table_catalog AS "database_name",
+               table_schema  AS "schema_name",
+               table_name    AS "name"
+        FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES
+        WHERE deleted IS NULL
+          AND table_type = 'VIEW'
+        """,
+    )
+    if from_account_usage is not None:
+        return from_account_usage
+
     show_result = execute(session, "SHOW VIEWS IN ACCOUNT", cacheable=True)
     views = []
     for row in show_result:

--- a/snowcap/operations/export.py
+++ b/snowcap/operations/export.py
@@ -14,7 +14,7 @@ from snowcap.resources.grant import grant_yaml
 
 logger = logging.getLogger("snowcap")
 
-DEFAULT_EXPORT_THREADS = 4
+DEFAULT_EXPORT_THREADS = 16
 
 
 def export_resources(
@@ -22,6 +22,7 @@ def export_resources(
     include: Optional[list[ResourceType]] = None,
     exclude: Optional[list[ResourceType]] = None,
     threads: int = DEFAULT_EXPORT_THREADS,
+    use_account_usage: bool = True,
 ) -> dict[str, list]:
     if session is None:
         session = connect()
@@ -41,7 +42,11 @@ def export_resources(
         if exclude and resource_type in exclude:
             continue
         try:
-            config.update(export_resource(session, resource_type, threads=threads))
+            config.update(
+                export_resource(
+                    session, resource_type, threads=threads, use_account_usage=use_account_usage
+                )
+            )
         # No list method for resource
         except AttributeError:
             logger.warning(f"Skipping {resource_type} because it has no list method")
@@ -73,10 +78,15 @@ def _fetch_resource_safe(session, urn: URN):
 
 
 def export_resource(
-    session, resource_type: ResourceType, threads: int = DEFAULT_EXPORT_THREADS
+    session,
+    resource_type: ResourceType,
+    threads: int = DEFAULT_EXPORT_THREADS,
+    use_account_usage: bool = True,
 ) -> dict[str, list]:
     resource_label = resource_label_for_type(resource_type)
-    resource_names = list_resource(session, resource_label)
+    # list_resource forwards only the kwargs a given list_* function declares, so this is a
+    # no-op for listers that don't support it (currently only list_grants does).
+    resource_names = list_resource(session, resource_label, use_account_usage=use_account_usage)
     if len(resource_names) == 0:
         return {}
 

--- a/snowcap/operations/export.py
+++ b/snowcap/operations/export.py
@@ -150,5 +150,13 @@ def _format_resource_config(urn: URN, resource: dict, resource_type: ResourceTyp
 
     if resource_type == ResourceType.SCHEMA:
         first_fields["database"] = str(urn.database().fqn)
+    elif urn.fqn.schema is not None and "schema" not in resource:
+        # Schema-scoped resources (file formats, stages, procedures, ...) were exported
+        # without their location, even though the URN carries it. That makes the output
+        # ambiguous whenever two schemas hold the same object name -- and unusable as
+        # plan/apply input, which rejects unqualified resources once a config spans more
+        # than one database. Emit the location we already know.
+        first_fields["database"] = str(urn.fqn.database)
+        first_fields["schema"] = str(urn.fqn.schema)
 
     return {**first_fields, **resource}


### PR DESCRIPTION
Opening as a **draft**  to demonstrate the problem. This is all Claude generated, and I would recommend to use this PR as inspiration only. The main problem is the 10K limit of SHOW. Beyond that Claude identified an O(n^2) grant lookup. In my case it reduced the import time from > 75 minutes (it never finished) to a few minutes. Because of the slow running it first tried to increase the threads from 4 to 16, that change wasn't needed in the end.

---------------------------------------------------------------------------------------------------------------------------------

On a large account (~15k tables, ~90k grants) `snowcap export --all` does not complete. Digging into it turned up three independent problems.

## 1. `SHOW ... IN ACCOUNT` is capped at 10,000 rows

`list_tables`, `list_views` and `list_stages` all use `SHOW ... IN ACCOUNT`, which Snowflake caps at 10,000 rows:

```
090153 (22000): The result set size exceeded the max number of rows(10000)
supported for SHOW statements. on SHOW TABLES IN ACCOUNT
```

Past that, listing fails outright and takes `plan`/`export` with it. They now read `SNOWFLAKE.ACCOUNT_USAGE`, falling back to `SHOW` when it is unavailable or errors.

**Trade-off, and the bit I would most like your view on:** `ACCOUNT_USAGE` lags live state (commonly up to ~2h), so a very recently created object can be missed. I made it the default on the reasoning that on an account past the cap a slightly stale answer beats no answer at all — but if you would rather it sat behind an explicit flag, or only engaged as a fallback *after* a 090153, I am glad to rework it.

## 2. `_show_grants_to_role` rescanned the whole grant cache per call

It re-filtered the entire cached `ACCOUNT_USAGE` grant list on every call. A 300-grant profile showed **32.7M `str.upper()` calls**. Now indexed by grantee, once per session.

## 3. `_fetch_grant_to_role` scanned a role's grants linearly

It walked the role's full grant list, constructing two `ResourceName` objects per candidate. Now indexed by `(granted_on, privilege, name)`.

`ResourceName` can't key a dict directly: `__hash__` is `hash(str(self))`, but `__eq__` treats quoted `"FOO"` and unquoted `FOO` as equal while `str()` keeps the quotes — so hash and equality disagree. `_grant_name_key` normalises to "exact if quoted, upper-cased otherwise", which reproduces `__eq__` across all four quoted/unquoted combinations.

Both indexes are invalidated in `reset_account_usage_caches` alongside the cache they derive from.

## Results

Measured on the affected account, 5,000-grant sample, steady state:

| | ms/grant | grant phase |
|---|---:|---:|
| before | 48.32 | ~74 min (projected) |
| after | **0.01** | **~1 s** |

`export --all --exclude=table,view`: **did not complete → 125 seconds**.

## Also included

- **`--threads` on `export`** (default raised 4 → 16) and **`--use-account-usage`** — neither was reachable from the CLI. Threads help the IO-bound resource types; the grant phase is CPU-bound and GIL-serialised, so only indexing addressed it.
- **Separate commit: qualify schema-scoped resources.** `export` omits `database`/`schema` from file formats, stages, procedures etc. even though the URN carries them. That makes output ambiguous when two schemas share an object name, and `plan`/`apply` reject unqualified resources once a config spans multiple databases (`Resource FILE FORMAT 'X' has no schema`) — so an `--all` export of a multi-database account can't be fed back in without hand-editing. Happy to split this into its own PR if you'd prefer.

## Not done

No tests added yet — I wanted to check the direction first, especially on the `ACCOUNT_USAGE` default. Glad to add coverage for the two index helpers and the qualification change if the approach looks right.