### PR TITLE
ci: bump GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -10,7 +10,7 @@ jobs:
       contents: write
     steps:
     - name: actions/checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
           persist-credentials: false
           fetch-depth: 0
@@ -18,7 +18,7 @@ jobs:
       run: echo "current_version=$(grep '# version' version.md | cut -d ' ' -f3)" >> $GITHUB_ENV
     - name: FragileTech/bump-version
       id: bump
-      uses: FragileTech/bump-version@main
+      uses: FragileTech/bump-version@v1.0.8
       with:
         current_version: "${{ env.current_version }}"
         files: version.md
@@ -38,7 +38,7 @@ jobs:
         echo "$NOTES" >> $GITHUB_OUTPUT
         echo "EOF" >> $GITHUB_OUTPUT
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: "v${{ env.next_version }}"
         name: "v${{ env.next_version }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,10 +23,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -38,7 +38,7 @@ jobs:
         run: mkdocs build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -51,4 +51,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: actions/checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
       - name: Create a virtual environment

--- a/.github/workflows/reset-test-account.yml
+++ b/.github/workflows/reset-test-account.yml
@@ -36,9 +36,9 @@ jobs:
     environment: ${{ matrix.environment }}
     steps:
       - name: actions/checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Create a virtual environment

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Create a virtual environment
@@ -37,6 +37,6 @@ jobs:
         make typecheck
         python -m pytest --ignore=tests/integration --cov=snowcap --cov-report=xml
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 


### PR DESCRIPTION
GitHub is [deprecating the Node 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for Actions. The `Bump package version` run surfaced the warning for `actions/checkout@v4` and `softprops/action-gh-release@v2`; auditing every workflow found more actions on Node 20.

## Changes
Bumped each Node 20 action to its lowest Node 24 major (minimal behavior change):

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v5** |
| `actions/setup-python` | v5 | **v6** |
| `codecov/codecov-action` | v4 | **v5** |
| `softprops/action-gh-release` | v2 | **v3** |
| `actions/upload-pages-artifact` | v3 | **v5** |
| `actions/deploy-pages` | v4 | **v5** |

- The Pages pair (`upload-pages-artifact` + `deploy-pages`) is bumped together to v5 so the artifact format stays compatible — `deploy-pages@v4` was also on Node 20.
- `codecov/codecov-action@v5` needs no input changes here (the step passes no positional inputs and relies on the `CODECOV_TOKEN` env var).

Also pinned `FragileTech/bump-version` from the moving `@main` branch to `@v1.0.8` for reproducibility. It's a shell composite action, so it isn't affected by the Node 20 deprecation itself — this is just supply-chain hygiene.

Verified: all workflow YAML still parses, and no Node 20 action pins remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)