### PR TITLE
feat(testing): make the provision key path configurable via SNOWCAP_TEST_KEY_PATH

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -97,9 +97,9 @@ python tools/manage_test_account.py provision --email you@example.com \
   --edition enterprise --cloud aws --region us_west_2
 ```
 
-`--cloud` requires `--region` to also be given. `--edition` defaults to your detected edition; `--admin-name` defaults to `SNOWCAP_ADMIN`; `--key-path` defaults to `$SNOWCAP_TEST_KEY_PATH` if that variable is set, otherwise `tests/.snowcap_test_account_rsa_key.p8`.
+`--cloud` requires `--region` to also be given. `--edition` defaults to your detected edition; `--admin-name` defaults to `SNOWCAP_ADMIN`; `--key-path` defaults to `~/.snowcap/snowcap_test_account_rsa_key.p8`, or `$SNOWCAP_TEST_KEY_PATH` if that variable is set.
 
-The admin key is the only credential for the account's `SERVICE` admin user. The in-checkout default is deleted with the checkout — for example when a git worktree is removed — and the account is then unrecoverable by self-service. Set `SNOWCAP_TEST_KEY_PATH` to a durable location outside the repository:
+The admin key is the only credential for the account's `SERVICE` admin user. Keep it outside the repository checkout: a key written into a checkout is deleted with it — for example when a git worktree is removed — and the account is then unrecoverable by self-service. The default already lives in your home directory; set `SNOWCAP_TEST_KEY_PATH` only to relocate it:
 
 ```bash
 export SNOWCAP_TEST_KEY_PATH=~/.keys/snowflake/snowcap_test_account_rsa_key.p8

--- a/TESTING.md
+++ b/TESTING.md
@@ -97,7 +97,13 @@ python tools/manage_test_account.py provision --email you@example.com \
   --edition enterprise --cloud aws --region us_west_2
 ```
 
-`--cloud` requires `--region` to also be given. `--edition` defaults to your detected edition; `--admin-name` defaults to `SNOWCAP_ADMIN`; `--key-path` defaults to `tests/.snowcap_test_account_rsa_key.p8`.
+`--cloud` requires `--region` to also be given. `--edition` defaults to your detected edition; `--admin-name` defaults to `SNOWCAP_ADMIN`; `--key-path` defaults to `$SNOWCAP_TEST_KEY_PATH` if that variable is set, otherwise `tests/.snowcap_test_account_rsa_key.p8`.
+
+The admin key is the only credential for the account's `SERVICE` admin user. The in-checkout default is deleted with the checkout — for example when a git worktree is removed — and the account is then unrecoverable by self-service. Set `SNOWCAP_TEST_KEY_PATH` to a durable location outside the repository:
+
+```bash
+export SNOWCAP_TEST_KEY_PATH=~/.keys/snowflake/snowcap_test_account_rsa_key.p8
+```
 
 Provisioning:
 

--- a/tests/test_manage_test_account.py
+++ b/tests/test_manage_test_account.py
@@ -34,6 +34,28 @@ _spec.loader.exec_module(manage_test_account)
 
 from snowcap.enums import AccountEdition  # noqa: E402
 
+
+def _load_module_copy():
+    spec = importlib.util.spec_from_file_location(
+        "manage_test_account_copy", REPO_ROOT / "tools" / "manage_test_account.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_key_path_honors_env_var(monkeypatch):
+    monkeypatch.setenv("SNOWCAP_TEST_KEY_PATH", "/durable/keys/test_key.p8")
+    module = _load_module_copy()
+    assert module.DEFAULT_KEY_PATH == "/durable/keys/test_key.p8"
+
+
+def test_default_key_path_falls_back_to_checkout(monkeypatch):
+    monkeypatch.delenv("SNOWCAP_TEST_KEY_PATH", raising=False)
+    module = _load_module_copy()
+    assert module.DEFAULT_KEY_PATH == str(REPO_ROOT / "tests" / ".snowcap_test_account_rsa_key.p8")
+
+
 # =============================================================================
 # create_account_sql
 # =============================================================================

--- a/tests/test_manage_test_account.py
+++ b/tests/test_manage_test_account.py
@@ -210,6 +210,18 @@ def test_generate_rsa_keypair_writes_pkcs8_pem_with_restrictive_mode(tmp_path):
     assert public_key.public_numbers() == private_key.public_key().public_numbers()
 
 
+def test_generate_rsa_keypair_creates_owner_only_key_dir(tmp_path):
+    # The key dir is created for the caller (e.g. ~/.snowcap); no group/other bits
+    # so the 0o600 key file's name isn't listable by other local users.
+    key_dir = tmp_path / ".snowcap"
+    key_path = key_dir / "key.p8"
+
+    manage_test_account.generate_rsa_keypair(key_path)
+
+    assert key_dir.is_dir()
+    assert key_dir.stat().st_mode & 0o077 == 0
+
+
 def test_generate_rsa_keypair_without_path_writes_no_file(tmp_path):
     result = manage_test_account.generate_rsa_keypair(None)
 

--- a/tests/test_manage_test_account.py
+++ b/tests/test_manage_test_account.py
@@ -50,10 +50,10 @@ def test_default_key_path_honors_env_var(monkeypatch):
     assert module.DEFAULT_KEY_PATH == "/durable/keys/test_key.p8"
 
 
-def test_default_key_path_falls_back_to_checkout(monkeypatch):
+def test_default_key_path_falls_back_to_home_directory(monkeypatch):
     monkeypatch.delenv("SNOWCAP_TEST_KEY_PATH", raising=False)
     module = _load_module_copy()
-    assert module.DEFAULT_KEY_PATH == str(REPO_ROOT / "tests" / ".snowcap_test_account_rsa_key.p8")
+    assert module.DEFAULT_KEY_PATH == str(pathlib.Path.home() / ".snowcap" / "snowcap_test_account_rsa_key.p8")
 
 
 # =============================================================================

--- a/tools/manage_test_account.py
+++ b/tools/manage_test_account.py
@@ -39,6 +39,15 @@ REPO_ROOT = SCRIPT_DIR.parent
 # Shared default so `provision --name` and `drop --name` always agree.
 DEFAULT_ACCOUNT_NAME = "SNOWCAP_TESTING"
 
+# The default key location sits inside the checkout, so deleting the checkout (e.g. a git
+# worktree) deletes the only credential for the test account's SERVICE admin. Contributors
+# can point SNOWCAP_TEST_KEY_PATH at a durable directory once instead of passing --key-path
+# on every provision.
+DEFAULT_KEY_PATH = os.environ.get(
+    "SNOWCAP_TEST_KEY_PATH",
+    str(REPO_ROOT / "tests" / ".snowcap_test_account_rsa_key.p8"),
+)
+
 # Snowflake's unquoted-identifier grammar; also doubles as our SQL-injection guard.
 IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_$]*$")
 
@@ -557,9 +566,9 @@ def teardown_and_reset():
 @click.option("--admin-name", default="SNOWCAP_ADMIN", show_default=True, help="Admin user name on the new account.")
 @click.option(
     "--key-path",
-    default=str(REPO_ROOT / "tests" / ".snowcap_test_account_rsa_key.p8"),
+    default=DEFAULT_KEY_PATH,
     show_default=True,
-    help="Where to write the new admin's private key.",
+    help="Where to write the new admin's private key. Defaults to $SNOWCAP_TEST_KEY_PATH if set.",
 )
 def provision(name, email, edition, cloud, region, admin_name, key_path):
     provision_test_account(name, email, edition, cloud, region, admin_name, key_path)

--- a/tools/manage_test_account.py
+++ b/tools/manage_test_account.py
@@ -301,7 +301,11 @@ def generate_rsa_keypair(key_path: pathlib.Path | None = None) -> str:
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=serialization.NoEncryption(),
         )
-        key_path.parent.mkdir(parents=True, exist_ok=True)
+        # Restrict the key directory to the owner so the 0o600 key file's name
+        # isn't even listable by other local users. ponytail: only tightens the
+        # dir we create; a pre-existing dir keeps its perms (mode is ignored when
+        # exist_ok and the dir already exists).
+        key_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "wb") as f:
             f.write(pem)

--- a/tools/manage_test_account.py
+++ b/tools/manage_test_account.py
@@ -39,13 +39,12 @@ REPO_ROOT = SCRIPT_DIR.parent
 # Shared default so `provision --name` and `drop --name` always agree.
 DEFAULT_ACCOUNT_NAME = "SNOWCAP_TESTING"
 
-# The default key location sits inside the checkout, so deleting the checkout (e.g. a git
-# worktree) deletes the only credential for the test account's SERVICE admin. Contributors
-# can point SNOWCAP_TEST_KEY_PATH at a durable directory once instead of passing --key-path
-# on every provision.
+# The admin key is the only credential for the test account's SERVICE admin, so it must
+# survive checkout deletion (e.g. a removed git worktree). Default to a durable per-user
+# location; SNOWCAP_TEST_KEY_PATH overrides it.
 DEFAULT_KEY_PATH = os.environ.get(
     "SNOWCAP_TEST_KEY_PATH",
-    str(REPO_ROOT / "tests" / ".snowcap_test_account_rsa_key.p8"),
+    str(pathlib.Path.home() / ".snowcap" / "snowcap_test_account_rsa_key.p8"),
 )
 
 # Snowflake's unquoted-identifier grammar; also doubles as our SQL-injection guard.
@@ -302,6 +301,7 @@ def generate_rsa_keypair(key_path: pathlib.Path | None = None) -> str:
             format=serialization.PrivateFormat.PKCS8,
             encryption_algorithm=serialization.NoEncryption(),
         )
+        key_path.parent.mkdir(parents=True, exist_ok=True)
         fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
         with os.fdopen(fd, "wb") as f:
             f.write(pem)


### PR DESCRIPTION
## Summary
`provision` wrote the test account admin's private key to `tests/.snowcap_test_account_rsa_key.p8` by default. That path lives inside the checkout, so deleting the checkout (for example, removing a git worktree) destroys the only credential for the account's SERVICE admin user. The account is then unrecoverable by self-service. This happened to us today.

## Changes
- `--key-path` now defaults to `~/.snowcap/snowcap_test_account_rsa_key.p8`, a durable per-user location outside any checkout
- `$SNOWCAP_TEST_KEY_PATH` overrides the default for users who keep keys elsewhere
- `generate_rsa_keypair` creates the parent directory if needed
- TESTING.md documents the risk and the override
- Unit tests pin the override and the home-directory fallback

## Testing
- `pytest tests/test_manage_test_account.py`: 72 passed
- `ruff check` and `ruff format --check` clean