### PR TITLE
Disable automated review actions for forks

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -29,6 +29,11 @@ permissions:
 jobs:
   triage:
     name: Triage (first pass)
+    # Keeps this workflow inert in forks, which get a copy of this file and run it
+    # on issues opened against the fork itself. Without the guard the triage job
+    # runs there, fails for want of CLAUDE_CODE_OAUTH_TOKEN, and the `comment` job
+    # still posts its fallback message on someone else's issue.
+    if: github.repository == 'datacoves/snowcap'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -168,7 +173,9 @@ jobs:
   comment:
     name: Post triage comment
     needs: triage
-    if: always()
+    # `always()` means this job runs even when `triage` is skipped, so it needs the
+    # same repository guard rather than inheriting it via `needs`.
+    if: always() && github.repository == 'datacoves/snowcap'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -26,7 +26,13 @@ permissions:
 jobs:
   review:
     name: Review (findings)
+    # The repository check keeps this workflow inert in forks. Forks get a copy of
+    # this file and run it on their OWN pull requests, where the head-repo check
+    # below passes (head and github.repository are both the fork) — so without this
+    # guard the review job runs there, fails for want of CLAUDE_CODE_OAUTH_TOKEN,
+    # and the `comment` job still posts its fallback message on someone else's PR.
     if: >-
+      github.repository == 'datacoves/snowcap' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
@@ -111,8 +117,11 @@ jobs:
   comment:
     name: Post review comment
     needs: review
+    # `always()` means this job runs even when `review` is skipped, so it needs the
+    # same repository guard rather than inheriting it via `needs`.
     if: >-
       always() &&
+      github.repository == 'datacoves/snowcap' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest


### PR DESCRIPTION
This gates the Claude issue/PR reviews to only run against the master repository, rather than trying to run on forks which are likely not set up for that sort of thing.