### PR TITLE
fix(warehouse): support fetch and diff of ADAPTIVE warehouses

### DIFF
--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -3321,9 +3321,11 @@ def fetch_warehouse(session: SnowflakeConnection, fqn: FQN, include_params: bool
     if include_params:
         show_params_result = execute(session, f"SHOW PARAMETERS FOR WAREHOUSE {fqn}")
         params = params_result_to_dict(show_params_result)
-        max_concurrency_level = params["max_concurrency_level"]
-        statement_queued_timeout = params["statement_queued_timeout_in_seconds"]
-        statement_timeout = params["statement_timeout_in_seconds"]
+        # ADAPTIVE warehouses omit max_concurrency_level from SHOW PARAMETERS entirely
+        # (verified live), so read every parameter defensively.
+        max_concurrency_level = params.get("max_concurrency_level")
+        statement_queued_timeout = params.get("statement_queued_timeout_in_seconds")
+        statement_timeout = params.get("statement_timeout_in_seconds")
     else:
         max_concurrency_level = None
         statement_queued_timeout = None
@@ -3338,6 +3340,7 @@ def fetch_warehouse(session: SnowflakeConnection, fqn: FQN, include_params: bool
     max_query_performance_level = _normalize_snowflake_optional(
         data.get("max_query_performance_level"), upper=True
     )
+    query_throughput_multiplier = _normalize_snowflake_optional(data.get("query_throughput_multiplier"))
 
     if warehouse_type == "STANDARD":
         if resource_constraint is None and generation in {"1", "2"}:
@@ -3366,6 +3369,7 @@ def fetch_warehouse(session: SnowflakeConnection, fqn: FQN, include_params: bool
         "generation": generation,
         "resource_constraint": resource_constraint,
         "max_query_performance_level": max_query_performance_level,
+        "query_throughput_multiplier": query_throughput_multiplier,
         "auto_suspend": data["auto_suspend"],
         "auto_resume": data["auto_resume"] == "true",
         "comment": data["comment"] or None,

--- a/snowcap/resources/warehouse.py
+++ b/snowcap/resources/warehouse.py
@@ -85,6 +85,7 @@ ADAPTIVE_UNSUPPORTED_FIELDS = (
     "enable_query_acceleration",
     "query_acceleration_max_scale_factor",
     "resource_constraint",
+    "max_concurrency_level",
 )
 
 
@@ -97,6 +98,7 @@ class _Warehouse(ResourceSpec):
     generation: Optional[WarehouseGeneration] = None
     resource_constraint: Optional[WarehouseResourceConstraint] = None
     max_query_performance_level: Optional[WarehouseSize] = None
+    query_throughput_multiplier: Optional[int] = None
     max_cluster_count: int = field(
         default=1,
         metadata={"edition": {AccountEdition.ENTERPRISE, AccountEdition.BUSINESS_CRITICAL}},
@@ -164,6 +166,9 @@ class _Warehouse(ResourceSpec):
             if self.max_query_performance_level in {WarehouseSize.X5LARGE, WarehouseSize.X6LARGE}:
                 raise ValueError("max_query_performance_level supports XSMALL through X4LARGE")
 
+        if self.query_throughput_multiplier is not None and self.warehouse_type != WarehouseType.ADAPTIVE:
+            raise ValueError("query_throughput_multiplier is only valid for ADAPTIVE warehouses")
+
 
 # Real dataclass defaults for the adaptive-inapplicable fields, computed once from
 # dataclasses.fields (the single source of truth) instead of rebuilding this dict on
@@ -182,11 +187,12 @@ class Warehouse(NamedResource, TaggableResource, Resource):
     Fields:
         name (string, required): The name of the warehouse.
         owner (string): The owner of the warehouse. Defaults to "SYSADMIN".
-        warehouse_type (string or WarehouseType): The type of the warehouse: STANDARD, SNOWPARK-OPTIMIZED, or ADAPTIVE. Defaults to STANDARD. ADAPTIVE warehouses do not support warehouse_size, min_cluster_count, max_cluster_count, scaling_policy, auto_suspend, auto_resume, initially_suspended, enable_query_acceleration, query_acceleration_max_scale_factor, resource_constraint, or generation.
+        warehouse_type (string or WarehouseType): The type of the warehouse: STANDARD, SNOWPARK-OPTIMIZED, or ADAPTIVE. Defaults to STANDARD. ADAPTIVE warehouses do not support warehouse_size, min_cluster_count, max_cluster_count, scaling_policy, auto_suspend, auto_resume, initially_suspended, enable_query_acceleration, query_acceleration_max_scale_factor, resource_constraint, generation, or max_concurrency_level.
         warehouse_size (string or WarehouseSize): The size of the warehouse which defines the compute and storage capacity.
         generation (string or WarehouseGeneration): The standard warehouse generation, either "1" or "2".
         resource_constraint (string or WarehouseResourceConstraint): The warehouse resource constraint, either STANDARD_GEN_1/2 for standard warehouses or MEMORY_* for Snowpark-optimized warehouses.
         max_query_performance_level (string or WarehouseSize): The maximum size an ADAPTIVE warehouse may scale to: XSMALL, SMALL, MEDIUM, LARGE, XLARGE, XXLARGE, XXXLARGE, or X4LARGE. Only valid for ADAPTIVE warehouses; Snowflake defaults to XLARGE if omitted.
+        query_throughput_multiplier (int): The query throughput multiplier for an ADAPTIVE warehouse. Only valid for ADAPTIVE warehouses; Snowflake defaults to 2 if omitted.
         max_cluster_count (int): The maximum number of clusters for the warehouse.
         min_cluster_count (int): The minimum number of clusters for the warehouse.
         scaling_policy (string or WarehouseScalingPolicy): The policy that defines how the warehouse scales.
@@ -197,7 +203,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         comment (string): A comment about the warehouse.
         enable_query_acceleration (bool): Whether query acceleration is enabled to improve performance. If omitted, Snowflake's default applies.
         query_acceleration_max_scale_factor (int): The maximum scale factor for query acceleration. If omitted, Snowflake's default applies.
-        max_concurrency_level (int): The maximum number of concurrent queries that the warehouse can handle.
+        max_concurrency_level (int): The maximum number of concurrent queries that the warehouse can handle. Not supported for ADAPTIVE warehouses.
         statement_queued_timeout_in_seconds (int): The time in seconds a statement can be queued before it times out.
         statement_timeout_in_seconds (int): The time in seconds a statement can run before it times out.
         tags (dict): Tags for the warehouse.
@@ -235,6 +241,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
             name="some_adaptive_warehouse",
             warehouse_type="ADAPTIVE",
             max_query_performance_level="LARGE",
+            query_throughput_multiplier=2,
         )
         ```
 
@@ -271,6 +278,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
           - name: some_adaptive_warehouse
             warehouse_type: ADAPTIVE
             max_query_performance_level: LARGE
+            query_throughput_multiplier: 2
         ```
     """
 
@@ -282,6 +290,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         generation=EnumProp("GENERATION", WarehouseGeneration, quoted=True),
         resource_constraint=EnumProp("RESOURCE_CONSTRAINT", WarehouseResourceConstraint),
         max_query_performance_level=EnumProp("MAX_QUERY_PERFORMANCE_LEVEL", WarehouseSize),
+        query_throughput_multiplier=IntProp("QUERY_THROUGHPUT_MULTIPLIER"),
         max_cluster_count=IntProp("max_cluster_count"),
         min_cluster_count=IntProp("min_cluster_count"),
         scaling_policy=EnumProp("scaling_policy", WarehouseScalingPolicy),
@@ -309,6 +318,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
         generation: str = None,
         resource_constraint: str = None,
         max_query_performance_level: str = None,
+        query_throughput_multiplier: Optional[int] = None,
         max_cluster_count: int = 1,
         min_cluster_count: int = 1,
         scaling_policy: str = "STANDARD",
@@ -334,6 +344,7 @@ class Warehouse(NamedResource, TaggableResource, Resource):
             generation=generation,
             resource_constraint=resource_constraint,
             max_query_performance_level=max_query_performance_level,
+            query_throughput_multiplier=query_throughput_multiplier,
             max_cluster_count=max_cluster_count,
             min_cluster_count=min_cluster_count,
             scaling_policy=scaling_policy,

--- a/tests/fixtures/json/warehouse.json
+++ b/tests/fixtures/json/warehouse.json
@@ -6,6 +6,7 @@
     "generation": "2",
     "resource_constraint": "STANDARD_GEN_2",
     "max_query_performance_level": null,
+    "query_throughput_multiplier": null,
     "max_cluster_count": 1,
     "min_cluster_count": 1,
     "scaling_policy": "STANDARD",

--- a/tests/test_blueprint.py
+++ b/tests/test_blueprint.py
@@ -895,6 +895,41 @@ def test_blueprint_standard_to_adaptive_warehouse_conversion(session_ctx):
     assert "ALTER WAREHOUSE WH SET warehouse_type = 'ADAPTIVE'" in sql
 
 
+def test_blueprint_adaptive_query_throughput_multiplier_no_drift_and_update(session_ctx):
+    # A fetched ADAPTIVE warehouse reports query_throughput_multiplier (default 2). A manifest
+    # declaring the same value must produce no plan; a different value must produce a
+    # single-field delta and the matching ALTER statement.
+    wh_urn = parse_URN("urn::ABCD123:warehouse/WH")
+    remote = _warehouse_remote_state(
+        type="ADAPTIVE",
+        size="",
+        max_query_performance_level="LARGE",
+        query_throughput_multiplier=2,
+    )
+    remote_state = {
+        parse_URN("urn::ABCD123:account/ACCOUNT"): {},
+        wh_urn: remote,
+    }
+
+    declared = dict(
+        name="WH",
+        warehouse_type="ADAPTIVE",
+        max_query_performance_level="LARGE",
+    )
+    blueprint = Blueprint(resources=[res.Warehouse(**declared, query_throughput_multiplier=2)])
+    manifest = blueprint.generate_manifest(session_ctx)
+    assert diff(remote_state, manifest) == []
+
+    blueprint = Blueprint(resources=[res.Warehouse(**declared, query_throughput_multiplier=4)])
+    manifest = blueprint.generate_manifest(session_ctx)
+    plan = diff(remote_state, manifest)
+    assert len(plan) == 1
+    assert plan[0].delta == {"query_throughput_multiplier": 4}
+
+    sql = flatten_sql_commands(compile_plan_to_sql(session_ctx, plan))
+    assert "ALTER WAREHOUSE WH SET QUERY_THROUGHPUT_MULTIPLIER = 4" in sql
+
+
 def test_blueprint_adaptive_to_standard_warehouse_conversion(session_ctx):
     # Symmetric reverse direction: remote is a fetched ADAPTIVE warehouse (fetch_warehouse nulls
     # ADAPTIVE_UNSUPPORTED_FIELDS -- size/cluster/suspend-resume/scaling -- to None), and the

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -1108,6 +1108,7 @@ class TestFetchWarehouse:
                 type="ADAPTIVE",
                 size="",
                 max_query_performance_level="LARGE",
+                query_throughput_multiplier=2,
                 max_cluster_count=4,
                 min_cluster_count=2,
                 scaling_policy="ECONOMY",
@@ -1119,9 +1120,9 @@ class TestFetchWarehouse:
 
         assert result["warehouse_type"] == "ADAPTIVE"
         assert result["max_query_performance_level"] == "LARGE"
+        assert result["query_throughput_multiplier"] == 2
         for field_name in ADAPTIVE_UNSUPPORTED_FIELDS:
             assert result.get(field_name) is None, field_name
-        assert "query_throughput_multiplier" not in result
 
     @patch("snowcap.data_provider._show_resources")
     def test_fetch_warehouse_adaptive_missing_columns(self, mock_show_resources):
@@ -1133,7 +1134,7 @@ class TestFetchWarehouse:
 
         assert result["max_query_performance_level"] is None
         assert result["warehouse_size"] is None
-        assert "query_throughput_multiplier" not in result
+        assert result["query_throughput_multiplier"] is None
 
     @patch("snowcap.data_provider._show_resources")
     def test_fetch_warehouse_adaptive_size_does_not_raise(self, mock_show_resources):
@@ -1174,7 +1175,28 @@ class TestFetchWarehouse:
             if field_name == "initially_suspended":
                 continue
             assert result[field_name] == value, field_name
-        assert "query_throughput_multiplier" not in result
+        assert result["query_throughput_multiplier"] is None
+
+    @patch("snowcap.data_provider.execute")
+    @patch("snowcap.data_provider._show_resources")
+    def test_fetch_warehouse_adaptive_params_omit_max_concurrency_level(self, mock_show_resources, mock_execute):
+        # Live ADAPTIVE warehouses return exactly these four parameters from SHOW
+        # PARAMETERS; max_concurrency_level is absent (issue #55), so an unconditional
+        # params["max_concurrency_level"] read raises KeyError.
+        mock_show_resources.return_value = [_warehouse_show_row(type="ADAPTIVE", size="")]
+        mock_execute.return_value = [
+            {"key": "ENABLE_USE_STABLE_PATH", "value": "true", "type": "BOOLEAN"},
+            {"key": "FALLBACK_WAREHOUSE", "value": "", "type": "STRING"},
+            {"key": "STATEMENT_QUEUED_TIMEOUT_IN_SECONDS", "value": "0", "type": "NUMBER"},
+            {"key": "STATEMENT_TIMEOUT_IN_SECONDS", "value": "172800", "type": "NUMBER"},
+        ]
+        mock_session = MagicMock()
+
+        result = fetch_warehouse(mock_session, FQN(name=ResourceName("WH")), include_params=True)
+
+        assert result["max_concurrency_level"] is None
+        assert result["statement_queued_timeout_in_seconds"] == 0
+        assert result["statement_timeout_in_seconds"] == 172800
 
 
 def _security_integration_show_row(**overrides):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -139,6 +139,7 @@ def test_warehouse_adaptive_construction_nulls_unsupported_fields():
         {"initially_suspended": True},
         {"enable_query_acceleration": True},
         {"resource_constraint": "STANDARD_GEN_2"},
+        {"max_concurrency_level": 8},
     ],
 )
 def test_warehouse_adaptive_rejects_unsupported_fields(kwargs):
@@ -177,6 +178,19 @@ def test_warehouse_adaptive_create_sql_with_optional_clauses():
     assert "MAX_QUERY_PERFORMANCE_LEVEL = X4LARGE" in sql
     assert "STATEMENT_TIMEOUT_IN_SECONDS = 3600" in sql
     assert "COMMENT = $$adaptive$$" in sql
+
+
+def test_warehouse_adaptive_query_throughput_multiplier_create_sql():
+    warehouse = res.Warehouse(name="WH", warehouse_type="ADAPTIVE", query_throughput_multiplier=4)
+    sql = warehouse.create_sql()
+    assert "QUERY_THROUGHPUT_MULTIPLIER = 4" in sql
+
+
+def test_warehouse_query_throughput_multiplier_requires_adaptive():
+    with pytest.raises(ValueError, match="query_throughput_multiplier"):
+        res.Warehouse(name="WH", query_throughput_multiplier=4)
+    with pytest.raises(ValueError, match="query_throughput_multiplier"):
+        res.Warehouse(name="WH", warehouse_type="SNOWPARK-OPTIMIZED", query_throughput_multiplier=4)
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Summary

Snowcap 1.0.21 creates ADAPTIVE warehouses but crashes on every later plan or apply. Snowflake omits `max_concurrency_level` from `SHOW PARAMETERS FOR WAREHOUSE` for ADAPTIVE warehouses, and `fetch_warehouse` indexed that key unconditionally, raising `KeyError`.

## Changes

- `fetch_warehouse` reads warehouse parameters with `params.get()`.
- `max_concurrency_level` joins `ADAPTIVE_UNSUPPORTED_FIELDS`: declared specs reject it and fetched state nulls it, so there is no drift.
- New ADAPTIVE-only field `query_throughput_multiplier` (spec, prop, validation, fetch). It is the remaining ADAPTIVE tuning knob Snowflake reports in `SHOW WAREHOUSES` and accepts in CREATE/ALTER.

## Ground truth (live probes on a test account)

`SHOW PARAMETERS` for an ADAPTIVE warehouse returns exactly 4 keys: `ENABLE_USE_STABLE_PATH`, `FALLBACK_WAREHOUSE`, `STATEMENT_QUEUED_TIMEOUT_IN_SECONDS`, `STATEMENT_TIMEOUT_IN_SECONDS`. ALTER accepts `MAX_QUERY_PERFORMANCE_LEVEL`, `QUERY_THROUGHPUT_MULTIPLIER`, `COMMENT`, `RESOURCE_MONITOR`, and the statement timeouts. ALTER rejects `MAX_CONCURRENCY_LEVEL`, `AUTO_SUSPEND`, `AUTO_RESUME`, `WAREHOUSE_SIZE`, and `INITIALLY_SUSPENDED` with "invalid property".

## Smoke test

Live run against the SNOWCAP_TESTING account through the snowcap API: create (snowcap-rendered SQL), fetch with params (the crash path), zero-drift plan for the same declared spec, ALTER of both adaptive knobs, drop. All passed.

Unit suite: 1837 passed.

Closes #55