### PR TITLE
fix(task): read WHEN back so triggered tasks stop re-planning

### DIFF
--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -3480,6 +3480,9 @@ def fetch_task(session: SnowflakeConnection, fqn: FQN, include_params: bool = Tr
         "owner": _get_owner_identifier(data),
         "comment": task_details["comment"] or None,
         "after": after or None,
+        # SHOW TASKS reports the WHEN clause in the 'condition' column. Without reading it back,
+        # a task with a WHEN never round-trips and snowcap re-plans "MODIFY WHEN ..." every apply.
+        "when": data["condition"] or None,
         "as_": task_details["definition"],
     }
 

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -39,6 +39,7 @@ from snowcap.data_provider import (
     fetch_grant,
     fetch_shared_database,
     fetch_security_integration,
+    fetch_task,
     fetch_warehouse,
     fetch_streamlit,
     list_resource,
@@ -968,6 +969,72 @@ def _warehouse_show_row(**overrides):
     }
     row.update(overrides)
     return row
+
+
+class TestFetchTask:
+    """Tests for fetch_task round-trip."""
+
+    @patch("snowcap.data_provider.execute")
+    @patch("snowcap.data_provider._show_resources")
+    def test_when_is_read_from_condition_column(self, mock_show_resources, mock_execute):
+        """A task's WHEN lives in the SHOW TASKS 'condition' column; fetch must read it back,
+        else a triggered task drifts 'MODIFY WHEN ...' on every apply."""
+        mock_show_resources.return_value = [
+            {
+                "name": "T1",
+                "warehouse": "",
+                "schedule": "",
+                "config": None,
+                "allow_overlapping_execution": "false",
+                "error_integration": "null",
+                "success_integration": "null",
+                "state": "suspended",
+                "condition": "system$stream_has_data('dynamic_table_stream')",
+                "target_completion_interval": "1 minutes",
+                "owner": "SYSADMIN",
+                "owner_role_type": "ROLE",
+            }
+        ]
+        mock_execute.return_value = [
+            {"task_relations": '{"Predecessors":[]}', "comment": None, "definition": "SELECT 1"}
+        ]
+
+        result = fetch_task(
+            MagicMock(),
+            FQN(name=ResourceName("T1"), database=ResourceName("DB"), schema=ResourceName("SCH")),
+            include_params=False,
+        )
+        assert result["when"] == "system$stream_has_data('dynamic_table_stream')"
+
+    @patch("snowcap.data_provider.execute")
+    @patch("snowcap.data_provider._show_resources")
+    def test_empty_condition_becomes_none(self, mock_show_resources, mock_execute):
+        mock_show_resources.return_value = [
+            {
+                "name": "T1",
+                "warehouse": "",
+                "schedule": "",
+                "config": None,
+                "allow_overlapping_execution": "false",
+                "error_integration": "null",
+                "success_integration": "null",
+                "state": "suspended",
+                "condition": "",
+                "target_completion_interval": "",
+                "owner": "SYSADMIN",
+                "owner_role_type": "ROLE",
+            }
+        ]
+        mock_execute.return_value = [
+            {"task_relations": '{"Predecessors":[]}', "comment": None, "definition": "SELECT 1"}
+        ]
+
+        result = fetch_task(
+            MagicMock(),
+            FQN(name=ResourceName("T1"), database=ResourceName("DB"), schema=ResourceName("SCH")),
+            include_params=False,
+        )
+        assert result["when"] is None
 
 
 class TestFetchWarehouse:


### PR DESCRIPTION
## Problem

A task with a `WHEN` clause never converges: every `plan` shows

```
~ UPDATE: <task>
  when   (empty)  →  system$stream_has_data('...')
```

even right after an `apply`. `fetch_task` returned every task field **except** `when`, so snowcap always saw the fetched `when` as empty, diffed it against the declared value, and re-emitted `ALTER TASK … MODIFY WHEN …` forever.

Surfaced by the balboa `capture_errors_task` (a serverless/triggered task added via #57/#59) — its `WHEN system$stream_has_data(...)` is the first `WHEN` under snowcap management.

## Fix

`SHOW TASKS` reports the `WHEN` predicate in the `condition` column. Map it back:

```python
"when": data["condition"] or None,
```

Empty `condition` (a task with no `WHEN`) normalizes to `None`, so unset tasks don't drift either.

## Tests

`TestFetchTask`: `when` is read from the `condition` column; empty `condition` → `None`. Full gate green (black, ruff, mypy, 2048 tests).