### PR TITLE
Fix ADAPTIVE warehouse fetch crash on adaptive-inapplicable fields

### DIFF
--- a/snowcap/resources/warehouse.py
+++ b/snowcap/resources/warehouse.py
@@ -156,7 +156,7 @@ class _Warehouse(ResourceSpec):
 
         if self.warehouse_type == WarehouseType.ADAPTIVE:
             for field_name in ADAPTIVE_UNSUPPORTED_FIELDS:
-                if getattr(self, field_name) != _ADAPTIVE_FIELD_DEFAULTS[field_name]:
+                if getattr(self, field_name) not in (None, _ADAPTIVE_FIELD_DEFAULTS[field_name]):
                     raise ValueError(f"{field_name} does not apply to ADAPTIVE warehouses")
                 setattr(self, field_name, None)
 

--- a/tests/integration/data_provider/test_fetch_resource_simple.py
+++ b/tests/integration/data_provider/test_fetch_resource_simple.py
@@ -307,6 +307,13 @@ def resource_fixtures() -> list:
             owner=TEST_ROLE,
             comment="This is a test warehouse",
         ),
+        res.Warehouse(
+            name="TEST_FETCH_ADAPTIVE_WAREHOUSE",
+            warehouse_type="ADAPTIVE",
+            max_query_performance_level="MEDIUM",
+            owner=TEST_ROLE,
+            comment="This is a test adaptive warehouse",
+        ),
     ]
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -127,6 +127,15 @@ def test_warehouse_adaptive_construction_nulls_unsupported_fields():
         assert getattr(warehouse._data, field_name) is None
 
 
+def test_warehouse_adaptive_accepts_none_for_unsupported_fields():
+    """The fetch path (data_provider) normalizes adaptive-inapplicable fields to None
+    before constructing the resource; validation must accept None as unset (issue #61)."""
+    kwargs = {field_name: None for field_name in ADAPTIVE_UNSUPPORTED_FIELDS}
+    warehouse = _Warehouse(name="WH", warehouse_type=WarehouseType.ADAPTIVE, **kwargs)
+    for field_name in ADAPTIVE_UNSUPPORTED_FIELDS:
+        assert getattr(warehouse, field_name) is None
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [


### PR DESCRIPTION
## Summary
Fixes #61. A `snowcap plan` or `apply` that fetches an existing ADAPTIVE warehouse crashed with `warehouse_size does not apply to ADAPTIVE warehouses`. The fetch path normalizes adaptive-inapplicable fields to `None`, but `_Warehouse.__post_init__` only accepted the dataclass defaults. Validation now accepts `None` as unset while still rejecting user-set values.

## Changes
- `snowcap/resources/warehouse.py`: the ADAPTIVE field check accepts `None` in addition to the dataclass default.
- `tests/test_resources.py`: regression test constructing `_Warehouse` with all adaptive-inapplicable fields set to `None`, mirroring fetched state.
- `tests/integration/data_provider/test_fetch_resource_simple.py`: new ADAPTIVE warehouse fixture; the fetch round-trip test exercises the exact live create/fetch/reconstruct path that crashed. Verified against the live test account with `--snowflake` (both warehouse cases pass).