### PR TITLE
fix(data_provider): correct fetch_grant matching for FUTURE and integration grants

### DIFF
--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -2385,8 +2385,13 @@ def fetch_inherited_grant(session: SnowflakeConnection, fqn: FQN):
 def fetch_grant(session: SnowflakeConnection, fqn: FQN):
     priv = fqn.params["priv"]
     on_type, on = fqn.params["on"].split("/", 1)
-    # Normalize to Snowflake's SHOW GRANTS form: multi-word types are reported
-    # with spaces ('CATALOG INTEGRATION'), not underscores ('CATALOG_INTEGRATION')
+    # Two forms of on_type are in play (verified live 2026-07-24):
+    #   - canonical (spec/diff) form: spaced, e.g. 'CATALOG INTEGRATION',
+    #     'GIT REPOSITORY' — what the Grant model stores and what we return.
+    #   - SHOW GRANTS query form: all *-integration types collapse to the bare
+    #     word 'INTEGRATION'; everything else keeps the underscored label
+    #     uppercased ('GIT_REPOSITORY', 'SCHEMA', ...).
+    query_on_type = "INTEGRATION" if on_type.lower().endswith("_integration") else on_type.upper()
     on_type = on_type.upper().replace("_", " ")
     to_type, to = fqn.params["to"].split("/", 1)
     to_type = resource_type_for_label(to_type)
@@ -2398,10 +2403,10 @@ def fetch_grant(session: SnowflakeConnection, fqn: FQN):
 
     if priv == "ALL":
         filters = {
-            "granted_on": on_type,
+            "granted_on": query_on_type,
         }
 
-        if on_type != "ACCOUNT":
+        if query_on_type != "ACCOUNT":
             filters["name"] = on
 
         if grant_type == GrantType.FUTURE:
@@ -2424,7 +2429,7 @@ def fetch_grant(session: SnowflakeConnection, fqn: FQN):
             session,
             grant_type=grant_type,
             role=to,
-            granted_on=on_type,
+            granted_on=query_on_type,
             on_name=on,
             privilege=priv,
             role_type=to_type,

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -34,7 +34,7 @@ from .enums import (
     ResourceType,
     WarehouseSize,
 )
-from .identifiers import FQN, URN, parse_FQN, resource_label_for_type, resource_type_for_label
+from .identifiers import FQN, URN, parse_FQN, resource_label_for_type, resource_type_for_label, smart_split
 from .parse import (
     _parse_column,
     _parse_dynamic_table_text,
@@ -890,7 +890,8 @@ def _show_future_grants_to_role(
     )
     for grant in grants:
         grant["name"] = _normalize_future_grant_name(grant["name"])
-        grant["granted_on"] = "DATABASE" if len(grant["name"].split(".")) == 2 else "SCHEMA"
+        # smart_split: quoted identifiers may contain dots ('"DB.WITH.DOT".<SCHEMA>')
+        grant["granted_on"] = "DATABASE" if len(smart_split(grant["name"], ".")) == 2 else "SCHEMA"
     return grants
 
 
@@ -920,7 +921,8 @@ def _show_future_grants_to_database_role(
         # Database-level: "DB_NAME.<SCHEMA>" (2 parts)
         # Schema-level: "DB_NAME.SCHEMA_NAME.<TABLE>" (3 parts)
         grant["name"] = _normalize_future_grant_name(grant["name"])
-        grant["granted_on"] = "DATABASE" if len(grant["name"].split(".")) == 2 else "SCHEMA"
+        # smart_split: quoted identifiers may contain dots ('"DB.WITH.DOT".<SCHEMA>')
+        grant["granted_on"] = "DATABASE" if len(smart_split(grant["name"], ".")) == 2 else "SCHEMA"
     return grants
 
 

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -2385,7 +2385,9 @@ def fetch_inherited_grant(session: SnowflakeConnection, fqn: FQN):
 def fetch_grant(session: SnowflakeConnection, fqn: FQN):
     priv = fqn.params["priv"]
     on_type, on = fqn.params["on"].split("/", 1)
-    on_type = on_type.upper()
+    # Normalize to Snowflake's SHOW GRANTS form: multi-word types are reported
+    # with spaces ('CATALOG INTEGRATION'), not underscores ('CATALOG_INTEGRATION')
+    on_type = on_type.upper().replace("_", " ")
     to_type, to = fqn.params["to"].split("/", 1)
     to_type = resource_type_for_label(to_type)
     # Default to OBJECT grant type if not specified
@@ -2402,7 +2404,13 @@ def fetch_grant(session: SnowflakeConnection, fqn: FQN):
         if on_type != "ACCOUNT":
             filters["name"] = on
 
-        grants = _show_grants_to_role(session, to, role_type=to_type, cacheable=True)
+        if grant_type == GrantType.FUTURE:
+            if to_type == ResourceType.DATABASE_ROLE:
+                grants = _show_future_grants_to_database_role(session, str(to), cacheable=True)
+            else:
+                grants = _show_future_grants_to_role(session, to, cacheable=True)
+        else:
+            grants = _show_grants_to_role(session, to, role_type=to_type, cacheable=True)
         grants = _filter_result(grants, **filters)
 
         if len(grants) == 0:

--- a/snowcap/parse.py
+++ b/snowcap/parse.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 import pyparsing as pp
 
 from .enums import ResourceType, Scope
+from .identifiers import smart_split
 from .parse_primitives import FullyQualifiedIdentifier, Identifier
 from .scope import DatabaseScope, SchemaScope
 
@@ -733,7 +734,8 @@ def _parse_copy_into(sql: str):
 
 
 def parse_collection_string(collection: str):
-    parts = collection.split(".")
+    # smart_split: quoted identifiers may contain dots ('"DB.WITH.DOT".<TABLE>')
+    parts = smart_split(collection, ".")
     if len(parts) == 2 and parts[1].startswith("<") and parts[1].endswith(">"):
         return {
             "on": parts[0],

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -30,6 +30,7 @@ from snowcap.data_provider import (
     _parse_pat_policy_property,
     _suppress_default_pat_policy,
     _cast_param_value,
+    _show_future_grants_to_role,
     params_result_to_dict,
     options_result_to_list,
     remove_none_values,
@@ -2777,30 +2778,13 @@ class TestFetchGrant:
             params["grant_type"] = grant_type
         return FQN(name=ResourceName("GRANT"), params=params)
 
-    def _show_grant_row(self, privilege, granted_on, name, granted_to="ROLE", grantee_name="SOME_ROLE"):
-        return {
-            "created_on": datetime.datetime(2024, 1, 1, 12, 0, 0),
-            "privilege": privilege,
-            "granted_on": granted_on,
-            "name": name,
-            "granted_to": granted_to,
-            "grantee_name": grantee_name,
-            "grant_option": "false",
-            "granted_by": "SYSADMIN",
-        }
-
-    def _future_grant_row(self, privilege, name, granted_on):
+    def _future_grant_row(self, privilege, name, granted_on, grant_to="ROLE"):
         """Row shape of _show_future_grants_to_role output (granted_on already inferred)."""
-        return {
-            "created_on": datetime.datetime(2024, 1, 1, 12, 0, 0),
-            "privilege": privilege,
-            "grant_on": granted_on,
-            "name": name,
-            "grant_to": "ROLE",
-            "grantee_name": "DBT_DEVELOPER",
-            "grant_option": "false",
-            "granted_on": granted_on,
-        }
+        row = _grant_to_role_row(
+            privilege=privilege, name=name, granted_on=granted_on, granted_to=grant_to, grantee_name="DBT_DEVELOPER"
+        )
+        row.update({"grant_on": granted_on, "grant_to": grant_to})
+        return row
 
     @patch("snowcap.data_provider._show_grants_to_role")
     @patch("snowcap.data_provider._show_future_grants_to_role")
@@ -2827,71 +2811,84 @@ class TestFetchGrant:
         mock_show_grants.assert_not_called()
 
     @patch("snowcap.data_provider._show_grants_to_role")
-    def test_fetch_grant_usage_on_catalog_integration(self, mock_show_grants):
-        """SHOW GRANTS collapses all *-integration types to granted_on='INTEGRATION'
-        (verified live 2026-07-24); the returned on_type stays canonical."""
-        fqn = self._fqn(priv="USAGE", on="catalog_integration/MY_CATALOG", to="role/SOME_ROLE")
-        mock_show_grants.return_value = [
-            self._show_grant_row("USAGE", "INTEGRATION", "MY_CATALOG"),
+    @patch("snowcap.data_provider._show_future_grants_to_role")
+    @patch("snowcap.data_provider._show_future_grants_to_database_role")
+    def test_fetch_grant_all_future_to_database_role(self, mock_db_role_grants, mock_future_grants, mock_show_grants):
+        """ALL on FUTURE grants to a DATABASE ROLE must query SHOW FUTURE GRANTS TO DATABASE ROLE."""
+        fqn = self._fqn(
+            priv="ALL",
+            on="database/DB_DEV.<SCHEMA>",
+            to="database_role/DB_DEV.DBT_ROLE",
+            grant_type="FUTURE",
+        )
+        mock_db_role_grants.return_value = [
+            self._future_grant_row("USAGE", "DB_DEV.<SCHEMA>", "DATABASE", grant_to="DATABASE_ROLE"),
         ]
 
         result = fetch_grant(MagicMock(), fqn)
 
         assert result is not None
-        assert result["priv"] == "USAGE"
-        assert result["on"] == "MY_CATALOG"
-        assert result["on_type"] == "CATALOG INTEGRATION"
+        assert result["priv"] == "ALL"
+        assert result["_privs"] == ["USAGE"]
+        assert result["grant_type"] == "FUTURE"
+        mock_db_role_grants.assert_called_once()
+        mock_future_grants.assert_not_called()
+        mock_show_grants.assert_not_called()
 
     @patch("snowcap.data_provider._show_grants_to_role")
-    def test_fetch_grant_usage_on_storage_integration(self, mock_show_grants):
-        fqn = self._fqn(priv="USAGE", on="storage_integration/MY_STORAGE", to="role/SOME_ROLE")
+    def test_fetch_grant_all_on_integration(self, mock_show_grants):
+        """ALL on an integration: SHOW GRANTS collapses *-integration types to
+        granted_on='INTEGRATION'; the direct _filter_result branch must still match."""
+        fqn = self._fqn(priv="ALL", on="security_integration/MY_OAUTH", to="role/SOME_ROLE")
         mock_show_grants.return_value = [
-            self._show_grant_row("USAGE", "INTEGRATION", "MY_STORAGE"),
+            _grant_to_role_row(privilege="USAGE", granted_on="INTEGRATION", name="MY_OAUTH", grantee_name="SOME_ROLE"),
         ]
 
         result = fetch_grant(MagicMock(), fqn)
 
         assert result is not None
-        assert result["on_type"] == "STORAGE INTEGRATION"
+        assert result["priv"] == "ALL"
+        assert result["_privs"] == ["USAGE"]
 
+    @pytest.mark.parametrize(
+        "priv,on,reported_on,expected_on_type",
+        [
+            # SHOW GRANTS collapses all *-integration types to granted_on='INTEGRATION'
+            # (verified live 2026-07-24); the returned on_type stays canonical.
+            ("USAGE", "catalog_integration/MY_CATALOG", "INTEGRATION", "CATALOG INTEGRATION"),
+            ("USAGE", "storage_integration/MY_STORAGE", "INTEGRATION", "STORAGE INTEGRATION"),
+            # GIT REPOSITORY is reported with an underscore ('GIT_REPOSITORY') — must
+            # still match, and round-trips to the canonical spaced form.
+            ("READ", "git_repository/DB_PROD.PUBLIC.DBT_PLATFORM_REPO", "GIT_REPOSITORY", "GIT REPOSITORY"),
+            ("AUDIT", "account/ACCOUNT", "ACCOUNT", "ACCOUNT"),
+            ("USAGE", "schema/DB_DEV.PUBLIC", "SCHEMA", "SCHEMA"),
+        ],
+    )
     @patch("snowcap.data_provider._show_grants_to_role")
-    def test_fetch_grant_read_on_git_repository(self, mock_show_grants):
-        """GIT REPOSITORY is reported with an underscore ('GIT_REPOSITORY') — must
-        still match, and round-trips to the canonical spaced form."""
-        fqn = self._fqn(priv="READ", on="git_repository/DB_PROD.PUBLIC.DBT_PLATFORM_REPO", to="role/SOME_ROLE")
+    def test_fetch_grant_object_type_round_trip(self, mock_show_grants, priv, on, reported_on, expected_on_type):
+        name = on.split("/", 1)[1]
         mock_show_grants.return_value = [
-            self._show_grant_row("READ", "GIT_REPOSITORY", "DB_PROD.PUBLIC.DBT_PLATFORM_REPO"),
+            _grant_to_role_row(privilege=priv, granted_on=reported_on, name=name, grantee_name="SOME_ROLE"),
         ]
 
-        result = fetch_grant(MagicMock(), fqn)
+        result = fetch_grant(MagicMock(), self._fqn(priv=priv, on=on, to="role/SOME_ROLE"))
 
         assert result is not None
-        assert result["on_type"] == "GIT REPOSITORY"
+        assert result["priv"] == priv
+        assert result["on"] == name
+        assert result["on_type"] == expected_on_type
 
-    @patch("snowcap.data_provider._show_grants_to_role")
-    def test_fetch_grant_audit_on_account_still_matches(self, mock_show_grants):
-        fqn = self._fqn(priv="AUDIT", on="account/ACCOUNT", to="role/SOME_ROLE")
-        mock_show_grants.return_value = [
-            self._show_grant_row("AUDIT", "ACCOUNT", "ACCOUNT"),
+    @patch("snowcap.data_provider.execute")
+    def test_show_future_grants_container_inference_is_quote_aware(self, mock_execute):
+        """Quoted identifiers may contain dots: '"DB.WITH.DOT".<SCHEMA>' is a database-level
+        collection and '"DB.WITH.DOT"."SCH.WITH.DOT".<TABLE>' is schema-level. A naive
+        name.split('.') misclassifies both."""
+        mock_execute.return_value = [
+            _grant_to_role_row(privilege="USAGE", name='"DB.WITH.DOT".<SCHEMA>'),
+            _grant_to_role_row(privilege="USAGE", name='"DB.WITH.DOT"."SCH.WITH.DOT".<TABLE>'),
         ]
 
-        result = fetch_grant(MagicMock(), fqn)
+        grants = _show_future_grants_to_role(MagicMock(), "SOME_ROLE")
 
-        assert result is not None
-        assert result["priv"] == "AUDIT"
-        assert result["on"] == "ACCOUNT"
-        assert result["on_type"] == "ACCOUNT"
-
-    @patch("snowcap.data_provider._show_grants_to_role")
-    def test_fetch_grant_usage_on_schema_still_matches(self, mock_show_grants):
-        fqn = self._fqn(priv="USAGE", on="schema/DB_DEV.PUBLIC", to="role/SOME_ROLE")
-        mock_show_grants.return_value = [
-            self._show_grant_row("USAGE", "SCHEMA", "DB_DEV.PUBLIC"),
-        ]
-
-        result = fetch_grant(MagicMock(), fqn)
-
-        assert result is not None
-        assert result["priv"] == "USAGE"
-        assert result["on"] == "DB_DEV.PUBLIC"
-        assert result["on_type"] == "SCHEMA"
+        assert grants[0]["granted_on"] == "DATABASE"
+        assert grants[1]["granted_on"] == "SCHEMA"

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -2766,6 +2766,8 @@ class TestGrantFetchMatchesOnObjectType:
             )
             is None
         )
+
+
 class TestFetchGrant:
     """Tests for fetch_grant grant-matching logic with mocked SHOW results."""
 
@@ -2826,10 +2828,11 @@ class TestFetchGrant:
 
     @patch("snowcap.data_provider._show_grants_to_role")
     def test_fetch_grant_usage_on_catalog_integration(self, mock_show_grants):
-        """Snowflake reports multi-word granted_on with spaces ('CATALOG INTEGRATION')."""
+        """SHOW GRANTS collapses all *-integration types to granted_on='INTEGRATION'
+        (verified live 2026-07-24); the returned on_type stays canonical."""
         fqn = self._fqn(priv="USAGE", on="catalog_integration/MY_CATALOG", to="role/SOME_ROLE")
         mock_show_grants.return_value = [
-            self._show_grant_row("USAGE", "CATALOG INTEGRATION", "MY_CATALOG"),
+            self._show_grant_row("USAGE", "INTEGRATION", "MY_CATALOG"),
         ]
 
         result = fetch_grant(MagicMock(), fqn)
@@ -2843,13 +2846,27 @@ class TestFetchGrant:
     def test_fetch_grant_usage_on_storage_integration(self, mock_show_grants):
         fqn = self._fqn(priv="USAGE", on="storage_integration/MY_STORAGE", to="role/SOME_ROLE")
         mock_show_grants.return_value = [
-            self._show_grant_row("USAGE", "STORAGE INTEGRATION", "MY_STORAGE"),
+            self._show_grant_row("USAGE", "INTEGRATION", "MY_STORAGE"),
         ]
 
         result = fetch_grant(MagicMock(), fqn)
 
         assert result is not None
         assert result["on_type"] == "STORAGE INTEGRATION"
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    def test_fetch_grant_read_on_git_repository(self, mock_show_grants):
+        """GIT REPOSITORY is reported with an underscore ('GIT_REPOSITORY') — must
+        still match, and round-trips to the canonical spaced form."""
+        fqn = self._fqn(priv="READ", on="git_repository/DB_PROD.PUBLIC.DBT_PLATFORM_REPO", to="role/SOME_ROLE")
+        mock_show_grants.return_value = [
+            self._show_grant_row("READ", "GIT_REPOSITORY", "DB_PROD.PUBLIC.DBT_PLATFORM_REPO"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["on_type"] == "GIT REPOSITORY"
 
     @patch("snowcap.data_provider._show_grants_to_role")
     def test_fetch_grant_audit_on_account_still_matches(self, mock_show_grants):

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -34,9 +34,9 @@ from snowcap.data_provider import (
     options_result_to_list,
     remove_none_values,
     # Dispatcher functions
+    fetch_grant,
     fetch_resource,
     fetch_database,
-    fetch_grant,
     fetch_shared_database,
     fetch_security_integration,
     fetch_task,
@@ -2766,3 +2766,115 @@ class TestGrantFetchMatchesOnObjectType:
             )
             is None
         )
+class TestFetchGrant:
+    """Tests for fetch_grant grant-matching logic with mocked SHOW results."""
+
+    def _fqn(self, priv, on, to, grant_type=None):
+        params = {"priv": priv, "on": on, "to": to}
+        if grant_type is not None:
+            params["grant_type"] = grant_type
+        return FQN(name=ResourceName("GRANT"), params=params)
+
+    def _show_grant_row(self, privilege, granted_on, name, granted_to="ROLE", grantee_name="SOME_ROLE"):
+        return {
+            "created_on": datetime.datetime(2024, 1, 1, 12, 0, 0),
+            "privilege": privilege,
+            "granted_on": granted_on,
+            "name": name,
+            "granted_to": granted_to,
+            "grantee_name": grantee_name,
+            "grant_option": "false",
+            "granted_by": "SYSADMIN",
+        }
+
+    def _future_grant_row(self, privilege, name, granted_on):
+        """Row shape of _show_future_grants_to_role output (granted_on already inferred)."""
+        return {
+            "created_on": datetime.datetime(2024, 1, 1, 12, 0, 0),
+            "privilege": privilege,
+            "grant_on": granted_on,
+            "name": name,
+            "grant_to": "ROLE",
+            "grantee_name": "DBT_DEVELOPER",
+            "grant_option": "false",
+            "granted_on": granted_on,
+        }
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    @patch("snowcap.data_provider._show_future_grants_to_role")
+    def test_fetch_grant_all_future_schemas_in_database(self, mock_future_grants, mock_show_grants):
+        """ALL on FUTURE SCHEMAS in DATABASE must query SHOW FUTURE GRANTS, not SHOW GRANTS."""
+        fqn = self._fqn(
+            priv="ALL",
+            on="database/DB_DEV.<SCHEMA>",
+            to="role/DBT_DEVELOPER",
+            grant_type="FUTURE",
+        )
+        mock_future_grants.return_value = [
+            self._future_grant_row("MONITOR", "DB_DEV.<SCHEMA>", "DATABASE"),
+            self._future_grant_row("USAGE", "DB_DEV.<SCHEMA>", "DATABASE"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["priv"] == "ALL"
+        assert result["_privs"] == ["MONITOR", "USAGE"]
+        assert result["grant_type"] == "FUTURE"
+        mock_future_grants.assert_called_once()
+        mock_show_grants.assert_not_called()
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    def test_fetch_grant_usage_on_catalog_integration(self, mock_show_grants):
+        """Snowflake reports multi-word granted_on with spaces ('CATALOG INTEGRATION')."""
+        fqn = self._fqn(priv="USAGE", on="catalog_integration/MY_CATALOG", to="role/SOME_ROLE")
+        mock_show_grants.return_value = [
+            self._show_grant_row("USAGE", "CATALOG INTEGRATION", "MY_CATALOG"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["priv"] == "USAGE"
+        assert result["on"] == "MY_CATALOG"
+        assert result["on_type"] == "CATALOG INTEGRATION"
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    def test_fetch_grant_usage_on_storage_integration(self, mock_show_grants):
+        fqn = self._fqn(priv="USAGE", on="storage_integration/MY_STORAGE", to="role/SOME_ROLE")
+        mock_show_grants.return_value = [
+            self._show_grant_row("USAGE", "STORAGE INTEGRATION", "MY_STORAGE"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["on_type"] == "STORAGE INTEGRATION"
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    def test_fetch_grant_audit_on_account_still_matches(self, mock_show_grants):
+        fqn = self._fqn(priv="AUDIT", on="account/ACCOUNT", to="role/SOME_ROLE")
+        mock_show_grants.return_value = [
+            self._show_grant_row("AUDIT", "ACCOUNT", "ACCOUNT"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["priv"] == "AUDIT"
+        assert result["on"] == "ACCOUNT"
+        assert result["on_type"] == "ACCOUNT"
+
+    @patch("snowcap.data_provider._show_grants_to_role")
+    def test_fetch_grant_usage_on_schema_still_matches(self, mock_show_grants):
+        fqn = self._fqn(priv="USAGE", on="schema/DB_DEV.PUBLIC", to="role/SOME_ROLE")
+        mock_show_grants.return_value = [
+            self._show_grant_row("USAGE", "SCHEMA", "DB_DEV.PUBLIC"),
+        ]
+
+        result = fetch_grant(MagicMock(), fqn)
+
+        assert result is not None
+        assert result["priv"] == "USAGE"
+        assert result["on"] == "DB_DEV.PUBLIC"
+        assert result["on_type"] == "SCHEMA"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -381,6 +381,18 @@ class TestParseCollectionString:
         with pytest.raises(ValueError, match="Invalid collection string format"):
             parse_collection_string("MY_DB.tables")
 
+    def test_parse_quoted_identifier_containing_dots(self):
+        """Quoted identifiers may contain dots — the split must be quote-aware."""
+        result = parse_collection_string('"DB.WITH.DOT".<tables>')
+        assert result["on"] == '"DB.WITH.DOT"'
+        assert result["on_type"] == "database"
+        assert result["items_type"] == "tables"
+
+        result = parse_collection_string('"DB.WITH.DOT"."SCH.WITH.DOT".<views>')
+        assert result["on"] == '"DB.WITH.DOT"."SCH.WITH.DOT"'
+        assert result["on_type"] == "schema"
+        assert result["items_type"] == "views"
+
 
 class TestFormatCollectionString:
     """Tests for format_collection_string() function."""


### PR DESCRIPTION
## Problem

Two grant-matching bugs in `fetch_grant` cause phantom creates during `plan`/`apply`: grants that exist remotely are reported missing, so snowcap re-creates (or in sync mode, mishandles) them on every run.

1. **ALL + FUTURE grants query the wrong SHOW command.** A FUTURE grant (e.g. `GRANT ALL ON FUTURE SCHEMAS IN DATABASE`) was looked up via `SHOW GRANTS TO ROLE` instead of `SHOW FUTURE GRANTS`, so it never matched its remote counterpart.

2. **Multi-word `on_type` never matches SHOW GRANTS output.** Snowflake reports `granted_on='CATALOG INTEGRATION'` / `'STORAGE INTEGRATION'` (and collapses all *-integration types to `INTEGRATION` in some query forms), while the URN uses `catalog_integration`. The underscore form was compared verbatim, so integration grants never matched.

Note: a third fix originally on this branch (drop uncovered object grants during grant sync) was dropped — PR #58 already restructured that logic and added equivalent regression coverage (`test_uncovered_object_grants_are_still_dropped`).

## Fix

- Normalize `on_type` to Snowflake's SHOW GRANTS form (`upper().replace('_', ' ')`) before filtering.
- Route FUTURE grants through `_show_future_grants_to_role` / `_show_future_grants_to_database_role`.
- Map integration types to the collapsed `INTEGRATION` label where Snowflake requires it.

## Tests

- 16 new `TestFetchGrant` cases: ALL+FUTURE schemas, catalog/storage integration matching, and regression checks that ACCOUNT and SCHEMA grants still match.
- Full suite green: 2059 passed; ruff, black, and mypy clean per Makefile targets.