### PR TITLE
Ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,7 @@ celerybeat.pid
 
 # Environments
 .env
+.envrc
 .venv
 env/
 venv/


### PR DESCRIPTION
Adds `.envrc` (direnv per-developer environment config) to the Environments section of `.gitignore` so local direnv files are never committed.