### PR TITLE
fix(data_provider): fetch_semantic_view so SEMANTIC VIEW grants resolve

### DIFF
--- a/docs/resources/semantic_view.md
+++ b/docs/resources/semantic_view.md
@@ -41,6 +41,16 @@ grants:
   - priv: CREATE SEMANTIC VIEW
     on: schema somedb.someschema
     to: semantic_view_author_role
+
+  # Bulk + future grants. FUTURE is what survives a rebuild: a semantic view
+  # that dbt (or any CREATE OR REPLACE) recreates loses its object-level grants,
+  # but a future grant on the schema re-applies SELECT to the new object.
+  - priv: SELECT
+    on: all semantic views in schema somedb.someschema
+    to: analyst_role
+  - priv: SELECT
+    on: future semantic views in schema somedb.someschema
+    to: analyst_role
 ```
 
 ### Python
@@ -81,6 +91,20 @@ grant = Grant(
 The schema-scope privilege `CREATE SEMANTIC VIEW` is part of
 [Grant](grant.md) under `SchemaPriv` — see the schema-privileges example
 above.
+
+## How snowcap resolves a semantic view
+
+At plan time snowcap verifies that every grant target exists (`SHOW SEMANTIC
+VIEWS ... IN SCHEMA <db>.<schema>`) and reads back the grant itself from `SHOW
+GRANTS TO ROLE <role>` / `SHOW FUTURE GRANTS IN SCHEMA`, where Snowflake reports
+the object type as `SEMANTIC_VIEW`. A grant on a semantic view that does not
+exist yet fails the plan the same way a grant on a missing table does — create
+the view (dbt, DDL) before declaring grants on it, or use a `future semantic
+views in schema` grant, which needs only the schema to exist.
+
+`snowcap export` lists semantic views for `sync_resources` the same way it lists
+views and dynamic tables; the objects themselves are never created, altered, or
+dropped by snowcap — only their grants are managed.
 
 ## See also
 

--- a/snowcap/data_provider.py
+++ b/snowcap/data_provider.py
@@ -3249,6 +3249,28 @@ def fetch_security_integration(session: SnowflakeConnection, fqn: FQN):
     return None
 
 
+def fetch_semantic_view(session: SnowflakeConnection, fqn: FQN):
+    # SEMANTIC VIEW has no concrete resource class (its CREATE body -- tables,
+    # relationships, facts, dimensions, metrics -- is owned by dbt/DDL), so this
+    # exists for the same reason fetch_dbt_project does: resolving a grant that
+    # targets `semantic view <db>.<schema>.<name>`. Blueprint._fetch_remote_state
+    # calls fetch_resource(existence_only=True) on every grant target, which
+    # dispatches here by resource label; without it the whole plan aborts with
+    # "Error fetching reference urn::...:semantic_view/...".
+    semantic_views = _show_resources(session, "SEMANTIC VIEWS", fqn)
+    if len(semantic_views) == 0:
+        return None
+    if len(semantic_views) > 1:
+        raise Exception(f"Found multiple semantic views matching {fqn}")
+
+    data = semantic_views[0]
+    return {
+        "name": data["name"],
+        "owner": _get_owner_identifier(data),
+        "comment": data.get("comment") or None,
+    }
+
+
 def fetch_sequence(session: SnowflakeConnection, fqn: FQN):
     show_result = execute(session, f"SHOW SEQUENCES LIKE '{fqn.name}' IN SCHEMA {fqn.database}.{fqn.schema}")
     if len(show_result) == 0:
@@ -4921,6 +4943,10 @@ def list_security_integrations(session: SnowflakeConnection) -> list[FQN]:
             continue
         integrations.append(FQN(name=resource_name_from_snowflake_metadata(row["name"])))
     return integrations
+
+
+def list_semantic_views(session: SnowflakeConnection) -> list[FQN]:
+    return list_schema_scoped_resource(session, "SEMANTIC VIEWS")
 
 
 def list_sequences(session: SnowflakeConnection) -> list[FQN]:

--- a/tests/test_data_provider.py
+++ b/tests/test_data_provider.py
@@ -51,9 +51,11 @@ from snowcap.data_provider import (
     fetch_task,
     fetch_warehouse,
     fetch_streamlit,
+    fetch_semantic_view,
     list_resource,
     list_account_scoped_resource,
     list_schema_scoped_resource,
+    list_semantic_views,
     list_stages,
     list_tables,
     list_views,
@@ -3368,3 +3370,136 @@ class TestSchemaScopedListersUseAccountUsage:
         lister(MagicMock(), use_account_usage=False)
 
         assert mock_from_account_usage.call_args.kwargs["use_account_usage"] is False
+
+
+def _semantic_view_show_row(**overrides):
+    # Shape of one SHOW SEMANTIC VIEWS row (created_on / name / kind / database_name /
+    # schema_name / comment / owner / owner_role_type / extension).
+    row = {
+        "created_on": "2026-09-01 10:00:00.000 -0700",
+        "name": "SV_SALES",
+        "kind": "SEMANTIC_VIEW",
+        "database_name": "DB_PROD",
+        "schema_name": "SALES_ORDER_DASHBOARD",
+        "comment": "",
+        "owner": "DBT_DEPLOYER",
+        "owner_role_type": "ROLE",
+        "extension": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def _semantic_view_fqn(name="SV_SALES"):
+    return FQN(
+        database=ResourceName("DB_PROD"),
+        schema=ResourceName("SALES_ORDER_DASHBOARD"),
+        name=ResourceName(name),
+    )
+
+
+class TestFetchSemanticView:
+    """Tests for fetch_semantic_view.
+
+    SEMANTIC VIEW has no concrete resource class (the CREATE body lives in dbt/DDL), so
+    the only thing snowcap ever fetches is existence + owner + comment, the same way
+    fetch_dbt_project does for DBT PROJECT. Without this function a grant declared as
+    `on: semantic view <db>.<schema>.<sv>` fails the whole plan at reference-resolution
+    time with "Error fetching reference urn::...:semantic_view/...".
+    """
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_returns_name_owner_and_comment(self, mock_show_resources):
+        mock_show_resources.return_value = [_semantic_view_show_row(comment="Sales metrics")]
+        session = MagicMock()
+
+        result = fetch_semantic_view(session, _semantic_view_fqn())
+
+        mock_show_resources.assert_called_once_with(session, "SEMANTIC VIEWS", _semantic_view_fqn())
+        assert result == {
+            "name": "SV_SALES",
+            "owner": "DBT_DEPLOYER",
+            "comment": "Sales metrics",
+        }
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_empty_comment_collapses_to_none(self, mock_show_resources):
+        # SHOW reports an unset comment as "", the spec default is None; they must compare equal.
+        mock_show_resources.return_value = [_semantic_view_show_row(comment="")]
+
+        result = fetch_semantic_view(MagicMock(), _semantic_view_fqn())
+
+        assert result["comment"] is None
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_missing_semantic_view_returns_none(self, mock_show_resources):
+        mock_show_resources.return_value = []
+
+        assert fetch_semantic_view(MagicMock(), _semantic_view_fqn()) is None
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_multiple_matches_raise(self, mock_show_resources):
+        mock_show_resources.return_value = [_semantic_view_show_row(), _semantic_view_show_row()]
+
+        with pytest.raises(Exception, match="multiple semantic views"):
+            fetch_semantic_view(MagicMock(), _semantic_view_fqn())
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_fetch_resource_dispatches_semantic_view_urn(self, mock_show_resources):
+        # This is the plan-time reference check: Blueprint._fetch_remote_state resolves a
+        # grant's `on` target through fetch_resource(..., existence_only=True), which
+        # dispatches on urn.resource_label -> fetch_semantic_view.
+        mock_show_resources.return_value = [_semantic_view_show_row()]
+        urn = URN(resource_type=ResourceType.SEMANTIC_VIEW, fqn=_semantic_view_fqn(), account_locator="ABC123")
+
+        result = fetch_resource(MagicMock(), urn, include_params=False, existence_only=True)
+
+        assert result is not None
+        assert result["name"] == "SV_SALES"
+
+    @patch("snowcap.data_provider._show_resources")
+    def test_fetch_resource_reports_missing_semantic_view_as_none(self, mock_show_resources):
+        mock_show_resources.return_value = []
+        urn = URN(resource_type=ResourceType.SEMANTIC_VIEW, fqn=_semantic_view_fqn(), account_locator="ABC123")
+
+        assert fetch_resource(MagicMock(), urn, include_params=False, existence_only=True) is None
+
+
+class TestListSemanticViews:
+    """Tests for list_semantic_views (export / sync_resources listing)."""
+
+    @patch("snowcap.data_provider.execute")
+    def test_lists_semantic_views_in_account(self, mock_execute):
+        mock_execute.return_value = [
+            _semantic_view_show_row(),
+            _semantic_view_show_row(name="EVERHOUR", database_name="DB_PROD", schema_name="TIME_TRACKING"),
+        ]
+        session = MagicMock()
+
+        result = list_semantic_views(session)
+
+        mock_execute.assert_called_once_with(session, "SHOW SEMANTIC VIEWS IN ACCOUNT", cacheable=True)
+        assert result == [
+            _semantic_view_fqn(),
+            FQN(database=ResourceName("DB_PROD"), schema=ResourceName("TIME_TRACKING"), name=ResourceName("EVERHOUR")),
+        ]
+
+    @patch("snowcap.data_provider.execute")
+    def test_filters_system_databases(self, mock_execute):
+        mock_execute.return_value = [
+            _semantic_view_show_row(),
+            _semantic_view_show_row(name="SYS_SV", database_name="SNOWFLAKE", schema_name="CORE"),
+        ]
+
+        result = list_semantic_views(MagicMock())
+
+        assert [str(r.name) for r in result] == ["SV_SALES"]
+
+    @patch("snowcap.data_provider.list_semantic_views")
+    def test_list_resource_dispatches_semantic_view_label(self, mock_list):
+        mock_list.return_value = []
+        session = MagicMock()
+
+        list_resource(session, "semantic_view")
+
+        mock_list.assert_called_once_with(session)


### PR DESCRIPTION
## Problem

`ResourceType.SEMANTIC_VIEW` grants have parsed since 1.0.23 (`SemanticViewPriv`, plus `semantic view X`, `all semantic views in schema X`, `future semantic views in schema X` in the YAML grant grammar), but declaring one aborts the whole plan:

```
Error fetching reference urn::XXXXXXXX:semantic_view/DB.SCHEMA.SV_SALES: ...
```

Root cause: `Blueprint._fetch_remote_state` verifies every grant target via `fetch_resource(existence_only=True)`, which dispatches by resource label to `getattr(data_provider, "fetch_semantic_view")`. `data_provider.py` has no such function, so the lookup raises `AttributeError` and the plan dies before any diff is produced — every unrelated resource in the config is blocked along with it. Reproduced against a live account on 1.0.26 and confirmed still missing on `main` (v1.0.29).

## Fix

Adds the two missing `data_provider` entry points, mirroring how `fetch_dbt_project` (#25) and `fetch_streamlit` (#24) handle grant-only object types that snowcap never creates or alters itself:

- `fetch_semantic_view(session, fqn)` — `SHOW SEMANTIC VIEWS LIKE '<name>' IN SCHEMA <db>.<schema>` via `_show_resources`; returns `{name, owner, comment}`, `None` when absent, raises on multiple matches.
- `list_semantic_views(session)` — `list_schema_scoped_resource(session, "SEMANTIC VIEWS")`, so `snowcap export` / `sync_resources` enumerate semantic views like views and dynamic tables.
- `docs/resources/semantic_view.md` — documents bulk/future grants and how snowcap resolves a semantic view at plan time.

No resource class is added: the CREATE body (tables, relationships, facts, dimensions, metrics) stays owned by dbt/DDL; snowcap manages only the grants.

## Tests (9 new, in `tests/test_data_provider.py`)

`TestFetchSemanticView`
- `test_returns_name_owner_and_comment`
- `test_empty_comment_collapses_to_none`
- `test_missing_semantic_view_returns_none`
- `test_multiple_matches_raise`
- `test_fetch_resource_dispatches_semantic_view_urn`
- `test_fetch_resource_reports_missing_semantic_view_as_none`

`TestListSemanticViews`
- `test_lists_semantic_views_in_account`
- `test_filters_system_databases`
- `test_list_resource_dispatches_semantic_view_label`

Full suite: 2189 passed.

## Notes

- Snowflake supports `GRANT SELECT ON FUTURE SEMANTIC VIEWS IN SCHEMA <db>.<schema>`, and `SHOW GRANTS` / `SHOW FUTURE GRANTS` report the object type as `SEMANTIC_VIEW`. Future grants are the durable form for semantic views that dbt rebuilds with `CREATE OR REPLACE` (which drops object-level grants).
- Until this ships we are running the fork commit `usbrandon/snowcap@0d8f265` pinned by SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
